### PR TITLE
Fix Node.js version to prevent SlowBuffer error

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0",
+    "node": "22.x",
     "npm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Pin Node.js to v22.x to fix compatibility issue with buffer-equal-constant-time package used by JWT libraries. Node.js v25 removed SlowBuffer which caused deployment failures on Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)