### PR TITLE
Extract competitor reasons from AI platform responses

### DIFF
--- a/models/AeoReport.js
+++ b/models/AeoReport.js
@@ -89,7 +89,10 @@ const aeoReportSchema = new mongoose.Schema({
     status: { type: String, enum: ['checked', 'timeout', 'error'], default: 'checked' },
     position: { type: Number, default: null },
     snippet: { type: String, default: null },
-    competitors: [String],
+    competitors: [{
+      name: String,
+      reason: { type: String, default: null },
+    }],
     error: { type: String, default: null },
   }],
   tier: { type: String, enum: ['free', 'starter', 'pro', 'enterprise', null], default: null },

--- a/routes/publicVendorRoutes.js
+++ b/routes/publicVendorRoutes.js
@@ -1523,14 +1523,17 @@ router.post('/aeo-report', aeoRateLimiter, async (req, res) => {
     // the real AI platform queries (ChatGPT, Perplexity, Claude, etc.)
     if (platformResults.length > 0) {
       const companyLower = companyName.toLowerCase();
-      const competitorFreq = new Map(); // name -> { count, platforms[] }
+      const competitorFreq = new Map(); // name -> { count, platforms[], reason }
 
       for (const pr of platformResults) {
         if (pr.error || !pr.competitors || pr.competitors.length === 0) continue;
-        for (const name of pr.competitors) {
-          if (!name || name.toLowerCase().includes(companyLower)) continue;
+        for (const entry of pr.competitors) {
+          // Support both old string format and new { name, reason } format
+          const compName = typeof entry === 'string' ? entry : entry?.name;
+          const compReason = typeof entry === 'string' ? null : (entry?.reason || null);
+          if (!compName || compName.toLowerCase().includes(companyLower)) continue;
           // Normalise key: trim, collapse whitespace
-          const key = name.trim().replace(/\s+/g, ' ');
+          const key = compName.trim().replace(/\s+/g, ' ');
 
           // Production competitor filter — validates business name quality
           if (!isValidBusinessName(key)) continue;
@@ -1539,8 +1542,10 @@ router.post('/aeo-report', aeoRateLimiter, async (req, res) => {
           if (existing) {
             existing.count++;
             existing.platforms.push(pr.platformLabel);
+            // Keep the first non-null reason
+            if (!existing.reason && compReason) existing.reason = compReason;
           } else {
-            competitorFreq.set(key, { count: 1, platforms: [pr.platformLabel] });
+            competitorFreq.set(key, { count: 1, platforms: [pr.platformLabel], reason: compReason });
           }
         }
       }
@@ -1555,7 +1560,7 @@ router.post('/aeo-report', aeoRateLimiter, async (req, res) => {
         return {
           name,
           description: `Recommended by ${platformList}`,
-          reason: `Mentioned by ${data.count} of 6 AI platforms when asked for the best ${categoryLabel} in ${city}`,
+          reason: data.reason || null,
           website: null,
           strengths: data.platforms.map(p => `Mentioned by ${p}`),
         };

--- a/services/platformQuery/prompt.js
+++ b/services/platformQuery/prompt.js
@@ -226,19 +226,38 @@ export function parsePlatformResponse(responseText, companyName) {
     }
   }
 
-  // Extract competitor names — other companies mentioned in numbered/bulleted items
+  // Extract competitor names and reasons — other companies mentioned in numbered/bulleted items
   const competitors = [];
-  const listItemPattern = /(?:^|\n)\s*(?:\d+[.)]\s*\**|[-•*]\s+\**)\s*([^:\n*]+?)(?:\*\*)?(?:\s*[-–:]\s|\s*\n)/g;
+  // This pattern captures: name (group 1) and the rest of the line as reason (group 2)
+  const listItemWithReasonPattern = /(?:^|\n)\s*(?:\d+[.)]\s*\**|[-•*]\s+\**)\s*([^:\n*]+?)(?:\*\*)?(?:\s*[-–:]\s)([^\n]*)/g;
   let match;
-  while ((match = listItemPattern.exec(text)) !== null) {
+  while ((match = listItemWithReasonPattern.exec(text)) !== null) {
     const name = match[1].replace(/\*\*/g, '').trim();
+    const reason = (match[2] || '').replace(/\*\*/g, '').trim();
     if (
       name &&
       !name.toLowerCase().includes(companyLower) &&
-      !competitors.includes(name) &&
+      !competitors.some(c => c.name === name) &&
       isValidBusinessName(name)
     ) {
-      competitors.push(name);
+      competitors.push({ name, reason: reason || null });
+    }
+  }
+
+  // Second pass: catch list items without a reason separator (name only, no colon/dash)
+  if (competitors.length === 0) {
+    const listItemNameOnly = /(?:^|\n)\s*(?:\d+[.)]\s*\**|[-•*]\s+\**)\s*([^:\n*]+?)(?:\*\*)?(?:\s*\n)/g;
+    let nameMatch;
+    while ((nameMatch = listItemNameOnly.exec(text)) !== null) {
+      const name = nameMatch[1].replace(/\*\*/g, '').trim();
+      if (
+        name &&
+        !name.toLowerCase().includes(companyLower) &&
+        !competitors.some(c => c.name === name) &&
+        isValidBusinessName(name)
+      ) {
+        competitors.push({ name, reason: null });
+      }
     }
   }
 
@@ -251,10 +270,10 @@ export function parsePlatformResponse(responseText, companyName) {
       if (
         name &&
         !name.toLowerCase().includes(companyLower) &&
-        !competitors.includes(name) &&
+        !competitors.some(c => c.name === name) &&
         isValidBusinessName(name)
       ) {
-        competitors.push(name);
+        competitors.push({ name, reason: null });
       }
     }
   }


### PR DESCRIPTION
- parsePlatformResponse() now returns { name, reason } objects instead of plain strings for competitors
- Reason is extracted from text after the name separator (colon/dash)
- AeoReport.platformResults.competitors schema updated to store objects
- Aggregation preserves first non-null reason per competitor
- Backward compatible: aggregation handles both old string and new object formats

https://claude.ai/code/session_01X4pcgG5QbBM35xg9UEcSUB