### PR TITLE
fix: auto-generate slugs on vendor signup and via pre-save hook

### DIFF
--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -394,6 +394,25 @@ vendorSchema.pre('save', async function(next) {
   }
 });
 
+// Auto-generate slug if missing
+vendorSchema.pre('save', function(next) {
+  if (!this.slug && this.company) {
+    this.slug = this.company
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .trim();
+    if (this.location?.city) {
+      this.slug += '-' + this.location.city
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-');
+    }
+  }
+  next();
+});
+
 // Normalize website URL - add https:// if missing
 vendorSchema.pre('save', function(next) {
   if (this.contactInfo?.website) {

--- a/routes/vendorUploadRoutes.js
+++ b/routes/vendorUploadRoutes.js
@@ -102,6 +102,17 @@ router.post('/signup', signupLimiter, async (req, res) => {
         const existingVendor = await Vendor.findOne({ email });
         if (existingVendor) return res.status(400).json({ message: 'Vendor already exists.' });
 
+        // Generate URL slug from company name and city
+        const generateSlug = (company, city) => {
+            const base = `${company} ${city || ''}`
+                .toLowerCase()
+                .replace(/[^a-z0-9\s-]/g, '')
+                .replace(/\s+/g, '-')
+                .replace(/-+/g, '-')
+                .trim();
+            return base;
+        };
+
         // Don't hash password here - the Vendor model's pre-save hook handles hashing
         const newVendor = new Vendor({
             name,
@@ -109,6 +120,7 @@ router.post('/signup', signupLimiter, async (req, res) => {
             password,  // Plain password - will be hashed by model pre-save hook
             company,
             services,
+            slug: generateSlug(company),
             account: {
                 status: 'active'
             }


### PR DESCRIPTION
- Add slug generation in vendorUploadRoutes.js signup handler
- Add pre-save hook to Vendor.js that auto-generates slug from company name + city when slug is missing
- Fixes ~100+ Semrush errors from vendors without URL slugs

https://claude.ai/code/session_01X4pcgG5QbBM35xg9UEcSUB