### PR TITLE
fix: Stripe critical issues — price IDs, past_due downgrade, refund h…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,11 @@ GROK_API_KEY=your_grok_api_key
 STRIPE_SECRET_KEY=your_stripe_secret_key
 STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret
 
+# Stripe Price IDs (required for checkout)
+# These map to the subscription products in your Stripe dashboard
+STRIPE_VISIBLE_PRICE_ID=price_xxx
+STRIPE_VERIFIED_PRICE_ID=price_xxx
+
 # ======================
 # AUTH
 # ======================

--- a/jobs/scheduledReports.js
+++ b/jobs/scheduledReports.js
@@ -199,6 +199,81 @@ async function generateVendorReports(tier) {
 }
 
 /**
+ * Downgrade vendors with past_due subscriptions older than 7 days.
+ * Runs daily at 9am UTC.
+ */
+async function downgradePastDueVendors() {
+  logger.info('[ScheduledReports] Checking for past_due vendors to downgrade...');
+
+  try {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+    const vendors = await Vendor.find({
+      subscriptionStatus: 'past_due',
+      updatedAt: { $lt: sevenDaysAgo },
+    });
+
+    if (vendors.length === 0) {
+      logger.info('[ScheduledReports] No past_due vendors to downgrade.');
+      return;
+    }
+
+    logger.info(`[ScheduledReports] Found ${vendors.length} past_due vendor(s) to downgrade.`);
+
+    for (const vendor of vendors) {
+      try {
+        const previousTier = vendor.tier;
+        vendor.tier = 'free';
+        vendor.subscriptionStatus = 'cancelled';
+        vendor.stripeSubscriptionId = null;
+
+        if (vendor.account) {
+          vendor.account.tier = 'standard';
+        }
+
+        await vendor.save();
+
+        logger.info(`[ADMIN ACTION] auto_downgrade | vendorId: ${vendor._id} | previousTier: ${previousTier} | reason: past_due_7_days | time: ${new Date().toISOString()}`);
+
+        // Send downgrade notification email
+        if (vendor.email) {
+          try {
+            await sendEmail({
+              to: vendor.email,
+              subject: 'Your TendorAI Pro subscription has been cancelled',
+              html: `
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+                  <h2 style="color: #7c3aed;">Subscription Cancelled</h2>
+                  <p style="color: #374151; line-height: 1.6;">
+                    Your TendorAI Pro subscription has been cancelled due to a failed payment that was not resolved within 7 days.
+                  </p>
+                  <p style="color: #374151; line-height: 1.6;">
+                    Your account has been moved to the free tier. You can resubscribe at any time to restore your Pro features.
+                  </p>
+                  <a href="https://www.tendorai.com/for-vendors" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin-top: 8px;">Resubscribe</a>
+                  <p style="color: #9ca3af; font-size: 13px; margin-top: 24px;">
+                    Questions? Contact hello@tendorai.com
+                  </p>
+                </div>
+              `,
+              text: `Your TendorAI Pro subscription has been cancelled due to failed payment. Your account has been moved to the free tier. Resubscribe at https://www.tendorai.com/for-vendors. Contact hello@tendorai.com for help.`,
+            });
+          } catch (emailErr) {
+            logger.error(`[ScheduledReports] Downgrade email failed for ${vendor.company}:`, emailErr.message);
+          }
+        }
+      } catch (err) {
+        logger.error(`[ScheduledReports] Error downgrading vendor ${vendor._id}:`, err.message);
+      }
+    }
+
+    logger.info(`[ScheduledReports] Past_due downgrade complete: ${vendors.length} vendor(s) processed.`);
+  } catch (error) {
+    logger.error('[ScheduledReports] Error in downgradePastDueVendors:', error.message);
+  }
+}
+
+/**
  * Register cron jobs and start the scheduler.
  */
 export function startScheduledReports() {
@@ -225,8 +300,15 @@ export function startScheduledReports() {
     generateVendorReports('pro');
   });
 
+  // Past-due subscription downgrade: daily at 9am UTC
+  cron.schedule('0 9 * * *', () => {
+    logger.info('[ScheduledReports] Triggering past_due vendor downgrade check...');
+    downgradePastDueVendors();
+  });
+
   logger.info('[ScheduledReports] Cron jobs registered:');
   logger.info('  - AI mentions (weekly): every Sunday at 03:00 UTC');
   logger.info('  - Pro (monthly): 1st of every month at 06:00 UTC');
   logger.info('  - Pro (weekly): every Monday at 06:00 UTC');
+  logger.info('  - Past_due downgrade (daily): every day at 09:00 UTC');
 }

--- a/routes/stripeRoutes.js
+++ b/routes/stripeRoutes.js
@@ -401,6 +401,12 @@ router.post('/webhook', requireStripe, async (req, res) => {
         break;
       }
 
+      case 'charge.refunded': {
+        const charge = event.data.object;
+        await handleChargeRefunded(charge);
+        break;
+      }
+
       default:
         logger.info('Unhandled Stripe event type', { type: event.type });
     }
@@ -656,6 +662,71 @@ async function handlePaymentFailed(invoice) {
     }
   } catch (error) {
     logger.error('Error handling payment failure:', { error: error.message });
+  }
+}
+
+async function handleChargeRefunded(charge) {
+  const customerId = charge.customer;
+
+  try {
+    const vendor = await Vendor.findOne({ stripeCustomerId: customerId });
+    if (!vendor) {
+      logger.warn('Vendor not found for refund', { customerId });
+      return;
+    }
+
+    const previousTier = vendor.tier;
+    vendor.tier = 'free';
+    vendor.subscriptionStatus = 'cancelled';
+    vendor.stripeSubscriptionId = null;
+
+    if (vendor.account) {
+      vendor.account.tier = 'standard';
+    }
+
+    // Add note to vendor record
+    if (!vendor.notes) vendor.notes = [];
+    vendor.notes.push({
+      note: `Refund processed on ${new Date().toISOString().split('T')[0]}. Charge: ${charge.id}. Amount: £${(charge.amount_refunded / 100).toFixed(2)}`,
+      type: 'system',
+      priority: 'high',
+      addedAt: new Date(),
+    });
+
+    await vendor.save();
+
+    logger.info(`[ADMIN ACTION] refund_processed | vendorId: ${vendor._id} | previousTier: ${previousTier} | chargeId: ${charge.id} | amount: £${(charge.amount_refunded / 100).toFixed(2)} | time: ${new Date().toISOString()}`);
+
+    // Send refund confirmation email
+    if (vendor.email) {
+      try {
+        await sendEmail({
+          to: vendor.email,
+          subject: 'Your TendorAI refund has been processed',
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+              <h2 style="color: #7c3aed;">Refund Processed</h2>
+              <p style="color: #374151; line-height: 1.6;">
+                Your refund of <strong>&pound;${(charge.amount_refunded / 100).toFixed(2)}</strong> has been processed. It may take 5-10 business days to appear on your statement.
+              </p>
+              <p style="color: #374151; line-height: 1.6;">
+                Your account has been moved to the free tier. You can resubscribe at any time.
+              </p>
+              <a href="https://www.tendorai.com/for-vendors" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin-top: 8px;">Resubscribe</a>
+              <p style="color: #9ca3af; font-size: 13px; margin-top: 24px;">
+                Questions? Contact hello@tendorai.com
+              </p>
+            </div>
+          `,
+          text: `Your TendorAI refund of £${(charge.amount_refunded / 100).toFixed(2)} has been processed. Your account has been moved to the free tier. Resubscribe at https://www.tendorai.com/for-vendors. Contact hello@tendorai.com for help.`,
+        });
+        logger.info('Refund email sent', { vendorId: vendor._id });
+      } catch (emailErr) {
+        logger.error('Failed to send refund email', { error: emailErr.message, vendorId: vendor._id });
+      }
+    }
+  } catch (error) {
+    logger.error('Error handling charge refund:', { error: error.message });
   }
 }
 


### PR DESCRIPTION
…andler

- Add STRIPE_VISIBLE_PRICE_ID and STRIPE_VERIFIED_PRICE_ID to .env.example
- Add daily 9am cron job to auto-downgrade past_due vendors after 7 days (sends cancellation email, resets tier to free, clears Stripe IDs)
- Add charge.refunded webhook handler (downgrades to free, adds note, sends refund confirmation email with amount)
- All actions logged with [ADMIN ACTION] audit format

https://claude.ai/code/session_01X4pcgG5QbBM35xg9UEcSUB