### PR TITLE
fix(aeo-report): wire Places GBP check into LLM rescan path

### DIFF
--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -9,6 +9,7 @@
  */
 
 import Vendor from '../models/Vendor.js';
+import { checkGoogleBusinessProfile } from './googleBusinessProfile.js';
 
 // ─── Category labels (human-readable) ────────────────────────────────────────
 
@@ -839,6 +840,16 @@ export async function generateFullReport({ companyName, category, city, email, c
     hasGoogleBusiness: !!parsed.searchedCompany?.hasGoogleBusiness,
     summary: parsed.searchedCompany?.summary || null,
   };
+
+  // Override the LLM's hasGoogleBusiness guess with a real Places API lookup.
+  // On any failure, leave the LLM value intact so the rescan still completes.
+  try {
+    const gbp = await checkGoogleBusinessProfile(companyName, city);
+    searchedCompany.hasGoogleBusiness = gbp.state === 'pass' || gbp.state === 'amber';
+    searchedCompany.googleBusinessDetail = { state: gbp.state, summary: gbp.summary };
+  } catch (err) {
+    console.warn(`[AEO] GBP override failed for "${companyName}" in "${city}": ${err.message}`);
+  }
 
   // Build backward-compatible aiRecommendations array
   const aiRecommendations = competitors.map((c) => ({


### PR DESCRIPTION
## Summary

This is the **Surface 2/3 half of the Option A rollout** that was planned with PR #24 but never landed on `main`. The commit sat on a stale branch after PR #24 was merged — surfaced during verification. This PR cherry-picks it cleanly onto a fresh branch off current `main`.

- **Surface 1 (public free report)** is already live and unchanged: see PR #24 → `services/publicAeoReportBuilder.js` calls `checkGoogleBusinessProfile` as a post-detector step.
- **Surface 2 (Pro vendor rescan via `POST /api/vendors/aeo-rescan`)** and **Surface 3 (admin single/batch report generation)** both go through `services/aeoReportGenerator.js` (the LLM path) and are still returning the LLM's coerced `hasGoogleBusiness` boolean — hence the red "No Google Business Profile detected" the Pro dashboard shows.

## The change

`services/aeoReportGenerator.js` — 11 lines:

- Import `checkGoogleBusinessProfile` from `./googleBusinessProfile.js` (the shared module added in PR #24).
- After the LLM's `searchedCompany` object is built and before `generateFullReport` returns, call the Places check and override:
  - `searchedCompany.hasGoogleBusiness = gbp.state === 'pass' || gbp.state === 'amber'`
  - `searchedCompany.googleBusinessDetail = { state, summary }`
- Wrapped in `try/catch`. On any failure (Places outage, unexpected error), the LLM's original `hasGoogleBusiness` value is preserved and a `console.warn` is emitted — the rescan always completes.

## Scope and risk

Deliberately narrow:
- Only `services/aeoReportGenerator.js` is touched.
- Only `hasGoogleBusiness` and `googleBusinessDetail` are modified on the output.
- LLM prompts untouched, scoring weights untouched, no other `has*` field touched.
- The schema addition for `googleBusinessDetail` already shipped in PR #24, so no migration risk.
- `checkGoogleBusinessProfile` itself is unchanged (already caches, already never-throws); this is just wiring.

## Option B still queued

The broader Surface 2 inconsistency — score, sub-scores, gaps, competitors, and the non-GBP `has*` booleans are all still LLM-fabricated because `aeoReportGenerator.js` doesn't run the real detector — is **out of scope here**. Option B (consolidate Surface 2/3 onto `publicAeoReportBuilder.js`) is tracked separately.

## Test plan

Post-deploy:
- [ ] Trigger `POST /api/vendors/aeo-rescan` as a Pro vendor (e.g. TendorAI Ltd). Confirm the new `AeoReport` doc has `searchedCompany.hasGoogleBusiness === true` and `searchedCompany.googleBusinessDetail = { state: 'pass' | 'amber', summary: <non-empty> }`.
- [ ] Dashboard "AEO Score" widget renders GBP as green/amber, not red.
- [ ] Run `POST /api/admin/generate-full-report`. PDF no longer shows the "No Google Business Profile detected" red row.
- [ ] Resilience: with `GOOGLE_PLACES_API_KEY` unset or invalid, rescan still completes and the report is saved with the LLM's original `hasGoogleBusiness` guess (look for `[AEO] GBP override failed` in logs).

## Links

- PR #24 (Surface 1 + shared module, already merged): https://github.com/scottk-sour/ai-procurement-backend/pull/24