### PR TITLE
feat(aeo): wire real pricing/services/reviews checks, drop brand partnerships

### DIFF
--- a/models/AeoReport.js
+++ b/models/AeoReport.js
@@ -77,6 +77,12 @@ const aeoReportSchema = new mongoose.Schema({
       state: { type: String },
       summary: { type: String },
     },
+    reviewsDetail: {
+      state: { type: String },
+      summary: { type: String },
+      rating: { type: Number, default: null },
+      count: { type: Number, default: null },
+    },
     summary: { type: String, default: null },
   },
   competitors: [

--- a/services/aeoDetector.js
+++ b/services/aeoDetector.js
@@ -18,6 +18,23 @@ export const BLOG_PATHS = [
 /** Per-probe timeout for blog detection network calls. */
 export const BLOG_PROBE_TIMEOUT_MS = 5000;
 
+/** Approved pricing-page paths. Anchors to any of these (or deeper) on the home page get fetched. */
+export const PRICING_PATHS = ['/pricing', '/fees', '/costs', '/plans', '/prices'];
+
+/** Path prefixes that indicate a "service" or "practice area" sub-page. */
+export const SERVICE_PATH_PREFIXES = ['/services', '/practice-areas', '/what-we-do', '/expertise'];
+
+export const SUBPAGE_PROBE_TIMEOUT_MS = 5000;
+
+/** Minimum word count (visible text) that makes a service page count as "detailed". */
+export const SERVICE_MIN_WORDS = 300;
+
+/** Minimum distinct "£ + number" matches on a single page to count as pricing shown. */
+export const PRICING_MIN_SIGNALS = 2;
+
+/** Max linked sub-pages fetched when evaluating detailed service pages. Upper bound on blast radius. */
+export const SERVICE_MAX_PROBES = 8;
+
 export const BLOG_DETECTION_DEFAULT = Object.freeze({
   hasBlog: false,
   blogUrl: null,
@@ -184,6 +201,125 @@ export async function detectBlog(origin, html) {
     return { ...BLOG_DETECTION_DEFAULT };
   } catch {
     return { ...BLOG_DETECTION_DEFAULT };
+  }
+}
+
+/**
+ * Fetch a single sub-page as text. Never throws — returns '' on any failure
+ * so pricing/service detection can treat an unreachable sub-page the same as
+ * a missing one without bubbling up a report-killing error.
+ */
+async function fetchSubpageHtml(url) {
+  try {
+    const resp = await axios.get(url, {
+      timeout: SUBPAGE_PROBE_TIMEOUT_MS,
+      maxRedirects: 5,
+      validateStatus: (s) => s >= 200 && s < 300,
+      headers: { 'User-Agent': 'TendorAI-AEO-Audit/1.0', Accept: 'text/html' },
+    });
+    return typeof resp.data === 'string' ? resp.data : '';
+  } catch {
+    return '';
+  }
+}
+
+/** Strip scripts/styles, keep everything else intact — callers normalise further. */
+function stripScripts(html) {
+  return String(html || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '');
+}
+
+/** Visible-text word count. Shared shape with check #10 in analyseAeoSignals. */
+function countWords(html) {
+  const text = stripScripts(html)
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return 0;
+  return text.split(/\s+/).length;
+}
+
+/**
+ * Count distinct "£ + number" occurrences on a single page. "£299" and "£ 299"
+ * collapse to the same signal; "£299" and "£500" count as two.
+ */
+function countPricingSignals(html) {
+  const text = stripScripts(html);
+  const matches = text.match(/£\s*\d[\d,]*(?:\.\d+)?/g);
+  if (!matches) return 0;
+  const distinct = new Set(matches.map((m) => m.replace(/\s+/g, '')));
+  return distinct.size;
+}
+
+/**
+ * Does the site publish pricing? Passes if the home page OR any linked
+ * /pricing | /fees | /costs | /plans | /prices page carries at least
+ * PRICING_MIN_SIGNALS distinct "£ + number" combinations on that single page.
+ *
+ * Only pages reachable via an anchor on the home page are fetched — no
+ * speculative probing. Never throws.
+ */
+export async function checkPricing(origin, homeHtml) {
+  try {
+    if (countPricingSignals(homeHtml) >= PRICING_MIN_SIGNALS) return true;
+
+    const linkedPricingPaths = new Set();
+    for (const href of extractHrefs(homeHtml || '')) {
+      const p = resolveSameOriginPath(href, origin);
+      if (!p) continue;
+      for (const base of PRICING_PATHS) {
+        if (p === base || p.startsWith(`${base}/`)) {
+          linkedPricingPaths.add(p);
+          break;
+        }
+      }
+    }
+
+    for (const path of linkedPricingPaths) {
+      const html = await fetchSubpageHtml(`${origin}${path}`);
+      if (countPricingSignals(html) >= PRICING_MIN_SIGNALS) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does the site have detailed service pages? Passes if the home page links
+ * to at least 2 distinct sub-pages under /services/*, /practice-areas/*,
+ * /what-we-do/*, or /expertise/*, AND at least 2 of those fetched sub-pages
+ * carry >= SERVICE_MIN_WORDS of visible text. Index pages (e.g. /services)
+ * without a sub-path segment do not count. Never throws.
+ */
+export async function checkDetailedServices(origin, homeHtml) {
+  try {
+    const candidates = new Set();
+    for (const href of extractHrefs(homeHtml || '')) {
+      const p = resolveSameOriginPath(href, origin);
+      if (!p) continue;
+      for (const prefix of SERVICE_PATH_PREFIXES) {
+        if (p.startsWith(`${prefix}/`) && p.length > prefix.length + 1) {
+          candidates.add(p);
+          break;
+        }
+      }
+    }
+    if (candidates.size < 2) return false;
+
+    let deepPages = 0;
+    const toCheck = [...candidates].slice(0, SERVICE_MAX_PROBES);
+    for (const path of toCheck) {
+      const html = await fetchSubpageHtml(`${origin}${path}`);
+      if (countWords(html) >= SERVICE_MIN_WORDS) {
+        deepPages += 1;
+        if (deepPages >= 2) return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 
@@ -428,6 +564,8 @@ export async function runDetector({ websiteUrl }) {
 
   const origin = new URL(url).origin;
   const blogDetection = await detectBlog(origin, html);
+  const hasPricing = await checkPricing(origin, html);
+  const hasDetailedServices = await checkDetailedServices(origin, html);
   const { overallScore, checks, recommendations, tendoraiSchemaDetected } = analyseAeoSignals(html, url);
 
   return {
@@ -436,6 +574,8 @@ export async function runDetector({ websiteUrl }) {
     checks,
     recommendations,
     blogDetection,
+    hasPricing,
+    hasDetailedServices,
     tendoraiSchemaDetected,
   };
 }

--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -9,7 +9,7 @@
  */
 
 import Vendor from '../models/Vendor.js';
-import { checkGoogleBusinessProfile } from './googleBusinessProfile.js';
+import { checkGoogleBusinessProfile, checkGoogleReviews } from './googleBusinessProfile.js';
 
 // ─── Category labels (human-readable) ────────────────────────────────────────
 
@@ -849,6 +849,21 @@ export async function generateFullReport({ companyName, category, city, email, c
     searchedCompany.googleBusinessDetail = { state: gbp.state, summary: gbp.summary };
   } catch (err) {
     console.warn(`[AEO] GBP override failed for "${companyName}" in "${city}": ${err.message}`);
+  }
+
+  // Override the LLM's hasReviews guess with a real Places reviews lookup.
+  // Reuses the GBP lookup cache, so this costs zero extra Places calls.
+  try {
+    const reviews = await checkGoogleReviews(companyName, city);
+    searchedCompany.hasReviews = reviews.state === 'pass';
+    searchedCompany.reviewsDetail = {
+      state: reviews.state,
+      summary: reviews.summary,
+      rating: reviews.rating ?? null,
+      count: reviews.count ?? null,
+    };
+  } catch (err) {
+    console.warn(`[AEO] Reviews override failed for "${companyName}" in "${city}": ${err.message}`);
   }
 
   // Build backward-compatible aiRecommendations array

--- a/services/googleBusinessProfile.js
+++ b/services/googleBusinessProfile.js
@@ -1,8 +1,11 @@
 /**
- * Google Business Profile check via Google Places API (Text Search v1).
+ * Google Business Profile + Google Reviews checks via Google Places API
+ * (Text Search v1).
  *
- * Called as a post-detector step from services/publicAeoReportBuilder.js.
- * Must never throw — the report must still generate if Places is down.
+ * Both checks share a single Places lookup + 24h cache, so adding the reviews
+ * check costs zero extra API calls. Called as post-detector steps from
+ * services/publicAeoReportBuilder.js and services/aeoReportGenerator.js.
+ * Neither check throws — reports must still generate if Places is down.
  */
 
 import axios from 'axios';
@@ -17,28 +20,46 @@ const FIELD_MASK = [
   'places.shortFormattedAddress',
   'places.primaryType',
   'places.businessStatus',
+  'places.rating',
+  'places.userRatingCount',
 ].join(',');
 const TIMEOUT_MS = 5000;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
-const UNAVAILABLE_RESULT = Object.freeze({
+// At least 3 reviews before we mark the check as passing. 1-2 is barely a
+// signal; 3+ shows a pattern. Adjust once we see real-world data.
+const REVIEWS_MIN_COUNT = 3;
+
+const GBP_UNAVAILABLE_RESULT = Object.freeze({
   state: 'fail',
   summary: 'GBP check temporarily unavailable',
 });
-const FAIL_NOT_FOUND_RESULT = Object.freeze({
+const GBP_FAIL_NOT_FOUND_RESULT = Object.freeze({
   state: 'fail',
   summary: 'No Google Business Profile detected',
 });
-const AMBER_RESULT = Object.freeze({
+const GBP_AMBER_RESULT = Object.freeze({
   state: 'amber',
   summary:
     'Google Business Profile found but incomplete — add opening hours, photos, and description to strengthen AI recommendations',
 });
-const PASS_RESULT = Object.freeze({
+const GBP_PASS_RESULT = Object.freeze({
   state: 'pass',
   summary: 'Google Business Profile found and well-populated',
 });
 
+const REVIEWS_UNAVAILABLE_RESULT = Object.freeze({
+  state: 'fail',
+  summary: 'Google reviews check temporarily unavailable',
+});
+const REVIEWS_NO_GBP_RESULT = Object.freeze({
+  state: 'fail',
+  summary: 'No Google Business Profile found (reviews are tied to a GBP)',
+});
+
+// cache key -> { storedAt, lookup: { status, place? } }
+// status is 'ok' (place is the matched place object or null when no match) or
+// 'unavailable' (upstream API failure — do not retry for the TTL).
 const cache = new Map();
 
 function cacheKey(companyName, city) {
@@ -52,11 +73,11 @@ function cacheGet(key) {
     cache.delete(key);
     return null;
   }
-  return entry.value;
+  return entry.lookup;
 }
 
-function cacheSet(key, value) {
-  cache.set(key, { value, storedAt: Date.now() });
+function cacheSet(key, lookup) {
+  cache.set(key, { lookup, storedAt: Date.now() });
 }
 
 function findMatchingPlace(places, city) {
@@ -70,30 +91,21 @@ function findMatchingPlace(places, city) {
   return null;
 }
 
-function classifyPlace(place) {
-  const hasHours = !!place?.regularOpeningHours;
-  const hasPhotos = Array.isArray(place?.photos) && place.photos.length > 0;
-  const hasShortAddress =
-    typeof place?.shortFormattedAddress === 'string' && place.shortFormattedAddress.length > 0;
-  if (hasHours || hasPhotos || hasShortAddress) return PASS_RESULT;
-  return AMBER_RESULT;
-}
-
 /**
- * Check whether a Google Business Profile exists for this company + city.
- * Returns a tri-state result — never throws.
+ * Shared Places lookup. Returns a tri-state:
+ *   { status: 'ok', place: <place>|null }  — API succeeded; place may be null for no match
+ *   { status: 'unavailable' }              — API failed (missing key, timeout, non-2xx, malformed)
  *
- * @param {string} companyName
- * @param {string} city
- * @returns {Promise<{state: 'pass' | 'amber' | 'fail', summary: string}>}
+ * Result is cached under the company+city key so both GBP and Reviews checks
+ * on the same report share one Places call.
  */
-export async function checkGoogleBusinessProfile(companyName, city) {
-  if (!companyName || !city) return FAIL_NOT_FOUND_RESULT;
+async function lookupPlace(companyName, city) {
+  if (!companyName || !city) return { status: 'ok', place: null };
 
   const apiKey = process.env.GOOGLE_PLACES_API_KEY;
   if (!apiKey) {
     console.warn('[GBP] GOOGLE_PLACES_API_KEY not set — returning unavailable');
-    return UNAVAILABLE_RESULT;
+    return { status: 'unavailable' };
   }
 
   const key = cacheKey(companyName, city);
@@ -117,30 +129,97 @@ export async function checkGoogleBusinessProfile(companyName, city) {
     );
   } catch (err) {
     console.warn(`[GBP] Places API request failed for "${companyName}" in "${city}": ${err.code || err.message}`);
-    const result = UNAVAILABLE_RESULT;
-    cacheSet(key, result);
-    return result;
+    const lookup = { status: 'unavailable' };
+    cacheSet(key, lookup);
+    return lookup;
   }
 
   if (!response || response.status < 200 || response.status >= 300) {
     console.warn(`[GBP] Places API returned status ${response?.status} for "${companyName}" in "${city}"`);
-    const result = UNAVAILABLE_RESULT;
-    cacheSet(key, result);
-    return result;
+    const lookup = { status: 'unavailable' };
+    cacheSet(key, lookup);
+    return lookup;
   }
 
   const places = response?.data?.places;
   if (!Array.isArray(places)) {
     console.warn(`[GBP] Places API returned malformed body for "${companyName}" in "${city}"`);
-    const result = UNAVAILABLE_RESULT;
-    cacheSet(key, result);
-    return result;
+    const lookup = { status: 'unavailable' };
+    cacheSet(key, lookup);
+    return lookup;
   }
 
   const match = findMatchingPlace(places, city);
-  const result = match ? classifyPlace(match) : FAIL_NOT_FOUND_RESULT;
-  cacheSet(key, result);
-  return result;
+  const lookup = { status: 'ok', place: match || null };
+  cacheSet(key, lookup);
+  return lookup;
+}
+
+function classifyPlaceForGbp(place) {
+  const hasHours = !!place?.regularOpeningHours;
+  const hasPhotos = Array.isArray(place?.photos) && place.photos.length > 0;
+  const hasShortAddress =
+    typeof place?.shortFormattedAddress === 'string' && place.shortFormattedAddress.length > 0;
+  if (hasHours || hasPhotos || hasShortAddress) return GBP_PASS_RESULT;
+  return GBP_AMBER_RESULT;
+}
+
+function formatRating(rating) {
+  if (typeof rating !== 'number' || !Number.isFinite(rating)) return null;
+  return Number.isInteger(rating) ? `${rating}.0` : rating.toFixed(1);
+}
+
+/**
+ * Check whether a Google Business Profile exists for this company + city.
+ * Tri-state ('pass' | 'amber' | 'fail') — never throws.
+ *
+ * @param {string} companyName
+ * @param {string} city
+ * @returns {Promise<{state: 'pass' | 'amber' | 'fail', summary: string}>}
+ */
+export async function checkGoogleBusinessProfile(companyName, city) {
+  if (!companyName || !city) return GBP_FAIL_NOT_FOUND_RESULT;
+
+  const lookup = await lookupPlace(companyName, city);
+  if (lookup.status === 'unavailable') return GBP_UNAVAILABLE_RESULT;
+  if (!lookup.place) return GBP_FAIL_NOT_FOUND_RESULT;
+  return classifyPlaceForGbp(lookup.place);
+}
+
+/**
+ * Check whether this company's Google Business Profile carries at least
+ * REVIEWS_MIN_COUNT reviews. Reuses the GBP Places lookup cache — no extra
+ * API call. Never throws.
+ *
+ * @param {string} companyName
+ * @param {string} city
+ * @returns {Promise<{state: 'pass' | 'fail', summary: string, rating?: number, count?: number}>}
+ */
+export async function checkGoogleReviews(companyName, city) {
+  if (!companyName || !city) return REVIEWS_NO_GBP_RESULT;
+
+  const lookup = await lookupPlace(companyName, city);
+  if (lookup.status === 'unavailable') return REVIEWS_UNAVAILABLE_RESULT;
+  if (!lookup.place) return REVIEWS_NO_GBP_RESULT;
+
+  const place = lookup.place;
+  const rating = typeof place.rating === 'number' ? place.rating : null;
+  const count = typeof place.userRatingCount === 'number' ? place.userRatingCount : 0;
+
+  if (count >= REVIEWS_MIN_COUNT) {
+    const ratingStr = formatRating(rating);
+    const summary = ratingStr
+      ? `${count} Google reviews (${ratingStr}★ average)`
+      : `${count} Google reviews`;
+    return { state: 'pass', summary, rating: rating ?? undefined, count };
+  }
+
+  return {
+    state: 'fail',
+    summary: 'Fewer than 3 Google reviews — ask customers to leave a review',
+    rating: rating ?? undefined,
+    count,
+  };
 }
 
 export default checkGoogleBusinessProfile;

--- a/services/publicAeoReportBuilder.js
+++ b/services/publicAeoReportBuilder.js
@@ -13,7 +13,7 @@
 import { runDetector } from './aeoDetector.js';
 import { queryAllPlatforms } from './platformQuery/index.js';
 import { isValidBusinessName } from './platformQuery/prompt.js';
-import { checkGoogleBusinessProfile } from './googleBusinessProfile.js';
+import { checkGoogleBusinessProfile, checkGoogleReviews } from './googleBusinessProfile.js';
 import { computeIndustryAverage } from '../utils/computeIndustryAverage.js';
 import Vendor from '../models/Vendor.js';
 
@@ -81,10 +81,12 @@ const CATEGORY_NOUN = {
 // searchedCompany check booleans used for the "X of Y applicable checks
 // passing" counter. Tri-state: null/undefined = not checked (excluded),
 // true = passing, false = failing.
+// hasBrands is intentionally absent — brand-partnership claims cannot be
+// verified reliably via scraping, so the public report no longer renders
+// that row.
 const CHECK_KEYS = [
   'hasReviews',
   'hasPricing',
-  'hasBrands',
   'hasStructuredData',
   'hasDetailedServices',
   'hasSocialMedia',
@@ -247,9 +249,8 @@ function mapScoreBreakdown(detectorResult, platformResults) {
 
 /**
  * Populate legacy searchedCompany checklist booleans from real detector checks.
- * Booleans the current detector cannot verify (reviews, pricing, brands, detailed
- * services, Google Business) are left null — the frontend must render null as
- * "not checked" rather than a red NO.
+ * hasGoogleBusiness and hasReviews are filled in post-detector by Places API
+ * lookups. hasBrands is intentionally omitted (see CHECK_KEYS).
  */
 function mapSearchedCompany({ detectorResult, websiteUrl, summary }) {
   const byKey = Object.create(null);
@@ -257,10 +258,9 @@ function mapSearchedCompany({ detectorResult, websiteUrl, summary }) {
   return {
     website: websiteUrl || null,
     hasReviews: null,
-    hasPricing: null,
-    hasBrands: null,
+    hasPricing: detectorResult.hasPricing ?? null,
     hasStructuredData: byKey.schema?.passed ?? null,
-    hasDetailedServices: null,
+    hasDetailedServices: detectorResult.hasDetailedServices ?? null,
     hasSocialMedia: byKey.social?.passed ?? null,
     hasGoogleBusiness: null,
     summary: summary ?? null,
@@ -438,6 +438,8 @@ export async function buildPublicReport({
     overallScore: detectorRaw.overallScore,
     checks: detectorRaw.checks,
     blogDetection: detectorRaw.blogDetection,
+    hasPricing: detectorRaw.hasPricing ?? null,
+    hasDetailedServices: detectorRaw.hasDetailedServices ?? null,
     tendoraiSchemaDetected: detectorRaw.tendoraiSchemaDetected,
     fetchError: null,
     runAt: new Date(),
@@ -466,6 +468,15 @@ export async function buildPublicReport({
   const gbp = await checkGoogleBusinessProfile(companyName, city);
   searchedCompany.hasGoogleBusiness = gbp.state === 'fail' ? false : true;
   searchedCompany.googleBusinessDetail = { state: gbp.state, summary: gbp.summary };
+
+  const reviews = await checkGoogleReviews(companyName, city);
+  searchedCompany.hasReviews = reviews.state === 'pass';
+  searchedCompany.reviewsDetail = {
+    state: reviews.state,
+    summary: reviews.summary,
+    rating: reviews.rating ?? null,
+    count: reviews.count ?? null,
+  };
 
   const summary = buildSummary({
     companyName,


### PR DESCRIPTION
## Summary

Four scoped changes to the free public AEO report plus one matching override on the Pro LLM path. All deterministic checks; no new LLM calls; no extra Places API calls.

### 1. Pricing wired into the free report

New `checkPricing(origin, html)` in `services/aeoDetector.js`. Passes if the homepage OR any anchor-linked `/pricing | /fees | /costs | /plans | /prices` page carries **≥2 distinct "£ + number"** matches on that single page. Only pages actually linked from the homepage are fetched (no speculative probing). `runDetector` now returns `hasPricing`, and `publicAeoReportBuilder` populates `searchedCompany.hasPricing` from it instead of leaving it `null`.

### 2. Service Pages wired into the free report

New `checkDetailedServices(origin, html)` in `services/aeoDetector.js`. Passes if the homepage links to **≥2 distinct sub-pages** under `/services/*`, `/practice-areas/*`, `/what-we-do/*`, or `/expertise/*` (sub-path required — bare `/services` doesn't count), AND at least 2 of those fetched pages carry **≥300 words** of visible text. Caps at 8 probed pages to bound blast radius. `searchedCompany.hasDetailedServices` is now populated.

### 3. Google Reviews added as a real check

`services/googleBusinessProfile.js` field mask extended with `places.rating` and `places.userRatingCount`. Internals refactored so both GBP and the new reviews check share a single `lookupPlace()` + 24h cache — **zero extra Places API calls**. New exported `checkGoogleReviews(companyName, city)` returns `{ state: 'pass' | 'fail', summary, rating?, count? }`:

- No matching place → `fail`, "No Google Business Profile found (reviews are tied to a GBP)"
- `userRatingCount >= 3` → `pass`, e.g. "47 Google reviews (4.8★ average)"
- `userRatingCount < 3` → `fail`, "Fewer than 3 Google reviews — ask customers to leave a review"
- Places API unavailable → `fail`, with a distinct "temporarily unavailable" summary

Wired into the free report (`publicAeoReportBuilder.js`) as a post-detector step next to GBP, populating `searchedCompany.hasReviews` and `searchedCompany.reviewsDetail = { state, summary, rating, count }`. Also wired into the LLM path (`aeoReportGenerator.js`) with the same `try/catch` guard as the GBP override, so a Places failure never kills a rescan.

The 3-review threshold is deliberate — 1–2 reviews is barely a signal, 3+ shows a pattern. Easy to tune in a follow-up once we see real data.

### 4. Brand Partnerships removed from the public report output

`hasBrands` is no longer emitted on `searchedCompany` by `publicAeoReportBuilder.js` and is removed from `CHECK_KEYS` (the "X of Y applicable checks passing" counter). The schema field is **kept** in `models/AeoReport.js` for historical reports. The frontend row removal lives in `scottk-sour/tendorai-nextjs` and is not part of this PR — the backend change is safe to ship first; the frontend will just render the absent field as `null` ("not checked") until that separate commit lands.

## Model change

`AeoReport.searchedCompany.reviewsDetail` subschema added, mirroring the shape of `googleBusinessDetail`:

```js
reviewsDetail: {
  state: String,
  summary: String,
  rating: { type: Number, default: null },
  count:  { type: Number, default: null },
}
```

## Scope notes / intentional non-changes

- **Pricing / Service Pages on the LLM path**: not overridden in `aeoReportGenerator.js`. Task scope covered pricing and service-page detection for the free report only; the LLM path still uses its existing prompt-based detection, which the task required not to break.
- **Scoring weights**: not touched (explicit constraint).
- **Two-code-path architecture**: preserved. The deterministic detector and the LLM generator remain cleanly separated; only the Places-API post-processing step is shared.
- **GBP cache shape changed** (in-memory only): now stores raw `{ status, place }` instead of the classified result. No persistence, no migration needed, but every warm key will re-hit Places once after deploy.

## Test plan

Automated tests cannot be added here — repo `test` script is a placeholder (`"Tests will be configured in Week 3"`) with no harness for routes/services. Manual verification after deploy:

- [ ] Free AEO report on https://www.tendorai.com:
  - Pricing row: green (site shows £299)
  - Service Pages row: green or amber depending on actual content depth
  - Google Reviews row: reflects real review count + rating
  - Google Business Profile row: still green (regression)
  - Brand Partnerships row: **gone entirely**
- [ ] Free AEO report on https://www.irwinmitchell.com:
  - Pricing row: depends on whether they publish fees
  - Service Pages row: should be green (large firm, many practice areas)
  - Reviews row: should be green (hundreds of reviews expected)
  - GBP: green
- [ ] Pro vendor rescan on a firm with a GBP: confirm `searchedCompany.reviewsDetail` is populated and `hasReviews` is overridden from the LLM's guess.
- [ ] Pro vendor rescan with `GOOGLE_PLACES_API_KEY` temporarily unset: confirm rescan still completes, `hasReviews` falls back to the LLM guess with no 500.
- [ ] Confirm no regression in the `rateLimiter` tier gating from #27 / #28 (unrelated but same service).

## Risk

Low–moderate. Two new network-fetching deterministic checks add latency to the free report (bounded — sequential fetches, 5s per probe, capped at 8 service-page probes). Fetch failures degrade silently to `false`. The Places refactor is the only shared-state change; it's in-process memory only.

https://claude.ai/code/session_016wAoDkVoxGNnDcXdPiiWAr