### PR TITLE
fix(aeo-report): restore GBP pass detection after shared-lookup refactor

### DIFF
--- a/services/googleBusinessProfile.js
+++ b/services/googleBusinessProfile.js
@@ -80,13 +80,26 @@ function cacheSet(key, lookup) {
   cache.set(key, { lookup, storedAt: Date.now() });
 }
 
+// Lowercase + strip diacritics so "Cwmbrân" matches "Cwmbran" and similar.
+function normalizeForMatch(s) {
+  return String(s || '')
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .trim();
+}
+
 function findMatchingPlace(places, city) {
   if (!Array.isArray(places) || places.length === 0) return null;
-  const cityToken = String(city).toLowerCase().trim();
+  const cityToken = normalizeForMatch(city);
   if (!cityToken) return null;
   for (const place of places) {
-    const addr = typeof place?.formattedAddress === 'string' ? place.formattedAddress : '';
-    if (addr.toLowerCase().includes(cityToken)) return place;
+    const haystack = [
+      typeof place?.formattedAddress === 'string' ? place.formattedAddress : '',
+      typeof place?.shortFormattedAddress === 'string' ? place.shortFormattedAddress : '',
+      typeof place?.displayName?.text === 'string' ? place.displayName.text : '',
+    ].map(normalizeForMatch).join(' | ');
+    if (haystack.includes(cityToken)) return place;
   }
   return null;
 }


### PR DESCRIPTION
## Before / after

| | Before this fix | After this fix |
|---|---|---|
| TendorAI LTD (Cwmbran) GBP check | `state='fail'`, "No Google Business Profile detected" | `state='pass'` or `'amber'`, "Google Business Profile found…" |
| TendorAI LTD (Cwmbran) Reviews check | "No Google Business Profile found (reviews are tied to a GBP)" | Real rating + count (or "Fewer than 3 Google reviews" if low) |

## Where the bug lives

`services/googleBusinessProfile.js` — `findMatchingPlace()` (was lines 83–92, now 92–105).

The function only looked at `places.formattedAddress` for a verbatim, lowercase substring match against the submitted `city`. Two real-world inputs slip through that filter:

1. **Welsh diacritics.** Places API returns "Cwmbrân" in the formatted address; the form submits "Cwmbran". `"cwmbrân".includes("cwmbran")` is `false`.
2. **Post town ≠ locality.** Tendorai's address resolves with post town "Newport" in `formattedAddress`. "Cwmbran" never appears there — but it does appear in `shortFormattedAddress` and / or `displayName.text`.

Both fields are already in the `FIELD_MASK`, so the data is being fetched and discarded.

## Why PR #28 surfaced this and not earlier

Pre-PR-#28, `findMatchingPlace` returning `null` only sank `checkGoogleBusinessProfile` — the result was cached as `FAIL_NOT_FOUND_RESULT` and that was the end of it. PR #28 promoted the matched `place` (or `null`) into the shared cache value so `checkGoogleReviews` could read it without a second API call. That made the strict miss visible on both checks at once and easier to attribute, but the strictness was always wrong.

The strictness pre-dates PR #28, so technically this is not a *regression introduced* by the refactor — it's a latent bug the refactor exposed. The user-visible "GBP went from pass to fail" symptom is real either way; previously the cache was being populated against a slightly different code path that happened to retain a stale `pass` for the same key. Cache resets on every Render deploy, so the next deploy after PR #28 cleared it and tendorai.com fell to the strict path for the first time.

## The fix

`services/googleBusinessProfile.js`:

- New `normalizeForMatch(s)` helper: NFD-normalises, strips combining marks (`\p{M}`), lowercases, trims. So `"Cwmbrân"` and `"Cwmbran"` both become `"cwmbran"`.
- `findMatchingPlace` now joins `formattedAddress`, `shortFormattedAddress`, and `displayName.text` into a single haystack (each normalized) and tests the normalized city against that. Cross-city protection is preserved — a place with no mention of the city in *any* of those three fields still returns `null`.

No change to:
- `lookupPlace` return shape
- The 24h cache structure or sharing
- `checkGoogleBusinessProfile` / `checkGoogleReviews` consumers
- `FIELD_MASK` (the data was already fetched)

## Verification

Sanity-checked the normalizer locally:

```
normalize("Cwmbrân")  === "cwmbran"   ✓
normalize("Cwmbran")  === "cwmbran"   ✓
"123 Main St, Cwmbrân NP44 3AB, UK".normalized.includes("cwmbran")  === true   ✓
```

**Manual regression test (post-merge, post-Render-deploy):**
1. Submit the public free-AEO form for `companyName=TendorAI LTD`, `city=Cwmbran`, `websiteUrl=https://www.tendorai.com`.
2. Open the resulting report.
3. Confirm `searchedCompany.googleBusinessDetail.state` is `'pass'` or `'amber'`.
4. Confirm `searchedCompany.reviewsDetail` carries a non-null `rating` and `count`.
5. Spot-check a non-Welsh control (e.g. any Cardiff firm) still resolves the same as before.

## Risk

- Tiny — the change widens what counts as a match by adding two already-fetched fields. Worst case: a place that doesn't actually serve the queried city sneaks through if its `displayName` happens to include the city name. The cross-city protection still rejects places where none of the three fields mention the city.
- Rollback: revert this commit, redeploy. Cache flushes on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)