### PR TITLE
fix(aeo-report): strip UK company suffixes before Places textQuery

### DIFF
--- a/services/googleBusinessProfile.js
+++ b/services/googleBusinessProfile.js
@@ -104,6 +104,23 @@ function findMatchingPlace(places, city) {
   return null;
 }
 
+// Strip trailing UK company-form suffixes so the Places textQuery matches the
+// way a GBP is actually registered. A listing like "TendorAI" won't rank
+// against "TendorAI LTD Cwmbran" on a fresh GBP with no other signals. We only
+// strip suffixes at the end of the name — "Sons of Anarchy" stays intact, but
+// "Smith & Sons Ltd" becomes "Smith".
+const COMPANY_SUFFIX_RE = /[\s,]+(?:ltd|limited|llp|plc|co|company|uk|(?:&\s*|and\s+)sons|inc|incorporated)\.?$/i;
+
+function stripCompanySuffix(name) {
+  let s = String(name || '').replace(/\s+/g, ' ').trim();
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(COMPANY_SUFFIX_RE, '').trim();
+  } while (s !== prev && s.length > 0);
+  return s || String(name || '').trim();
+}
+
 /**
  * Shared Places lookup. Returns a tri-state:
  *   { status: 'ok', place: <place>|null }  — API succeeded; place may be null for no match
@@ -125,11 +142,13 @@ async function lookupPlace(companyName, city) {
   const cached = cacheGet(key);
   if (cached) return cached;
 
+  const queryName = stripCompanySuffix(companyName);
+
   let response;
   try {
     response = await axios.post(
       ENDPOINT,
-      { textQuery: `${companyName} ${city}` },
+      { textQuery: `${queryName} ${city}` },
       {
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Old vs new query string

| | Query sent to Places Text Search v1 |
|---|---|
| **Before this fix** | `"TendorAI LTD Cwmbran"` |
| **After this fix**  | `"TendorAI Cwmbran"` |

## Why this explains the bug

Ground truth (per live Google Maps lookup):
- GBP **display name**: `TendorAI`
- **Category**: Software company
- **Address**: 155 Oaksford, Ty Canol, Cwmbran NP44 6UN

The public free-AEO form captures the legal entity name (`TendorAI LTD`), not the display name. That raw form input was being concatenated verbatim into the Places textQuery in `services/googleBusinessProfile.js:132`:

```js
{ textQuery: `${companyName} ${city}` }
```

Places Text Search v1 is tolerant but not clairvoyant. A brand-new GBP with minimal review volume and no other strong ranking signals won't surface against a query that includes a trailing company-form token the profile never carried. The API returns a page of places — just not TendorAI's — and `findMatchingPlace` then correctly reports "no match" on whatever unrelated Cwmbran businesses came back.

PR #29 (just merged) widened the match-side filter to accept diacritics and multiple address fields, which is still a good change for other cases. But match-side changes can't fix a miss where the place wasn't in the response at all.

## The fix

New helper in `services/googleBusinessProfile.js`:

```js
const COMPANY_SUFFIX_RE = /[\s,]+(?:ltd|limited|llp|plc|co|company|uk|(?:&\s*|and\s+)sons|inc|incorporated)\.?$/i;

function stripCompanySuffix(name) {
  let s = String(name || '').replace(/\s+/g, ' ').trim();
  let prev;
  do {
    prev = s;
    s = s.replace(COMPANY_SUFFIX_RE, '').trim();
  } while (s !== prev && s.length > 0);
  return s || String(name || '').trim();
}
```

Used once in `lookupPlace`, only when building the textQuery. Cache key stays on the raw input.

Behaviour (verified by running the helper against a fixture set):

| Input | Output |
|---|---|
| `TendorAI LTD` | `TendorAI` |
| `TendorAI Ltd.` | `TendorAI` |
| `TendorAI` | `TendorAI` |
| `Acme Limited UK` | `Acme` |
| `Smith & Sons` | `Smith` |
| `Smith & Sons Ltd` | `Smith` |
| `Smith and Sons` | `Smith` |
| `Microsoft UK Ltd` | `Microsoft` |
| `Foo Co.` | `Foo` |
| `Baz, Inc.` | `Baz` |
| `LTD` *(whole name)* | `LTD` *(fallback, not stripped)* |
| `Sons of Anarchy` | `Sons of Anarchy` *(only strips at end)* |

Key properties:
- **Anchored at end** (`$`) — mid-name tokens like `Sons of Anarchy` or `UK Airlines` are preserved.
- **Requires separator** (`[\s,]+` before the match) — prevents cutting a suffix out of a word.
- **Repeated** — handles chains like `Microsoft UK Ltd` in one call.
- **Fallback** — if the entire name is a suffix (`LTD`), the function returns the original input rather than the empty string.

## Manual regression test (post-merge)

1. Submit the free AEO form with `companyName=TendorAI LTD`, `city=Cwmbran`, `websiteUrl=https://www.tendorai.com`.
2. Open the resulting report.
3. Expect `searchedCompany.googleBusinessDetail.state` = `'pass'` (TendorAI's GBP has category + address + Plus Code populated).
4. Expect `searchedCompany.reviewsDetail.count` and `.rating` to reflect TendorAI's real review state (likely 0 or a low number for a new profile).
5. Spot-check a control where the form input already matches the GBP display name (e.g. a firm submitted without "LTD") — should be unchanged.

## Risk

- Very low. The change only affects the string sent to Places; cache key, return shape, and consumers are unchanged.
- Edge case: a legal entity whose display name actually *does* include a stripped suffix (e.g. a company literally called "Acme Ltd" on Google Maps) will now be queried as "Acme", which is Places' preferred form anyway. Unlikely to regress.
- Rollback: revert this commit, redeploy. In-memory cache flushes on deploy so no stale data carries over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)