### PR TITLE
feat(aeo): dual scoring — Technical Health + AI Visibility (retire fabricated LLM score)

### DIFF
--- a/jobs/scheduledReports.js
+++ b/jobs/scheduledReports.js
@@ -179,12 +179,16 @@ async function generateVendorReports(tier) {
         continue;
       }
 
-      // Generate the full AEO report
+      // Generate the full AEO report. Plumb websiteUrl through so the
+      // deterministic detector can run — without it, dual scoring falls
+      // back to nulls.
+      const websiteUrl = vendor.contactInfo?.website || undefined;
       const reportData = await generateFullReport({
         companyName: vendor.company,
         category,
         city,
         email: vendor.email,
+        websiteUrl,
       });
 
       // Generate PDF

--- a/models/AeoReport.js
+++ b/models/AeoReport.js
@@ -55,6 +55,11 @@ const aeoReportSchema = new mongoose.Schema({
 
   // Full report fields (optional — basic reports won't have these)
   reportType: { type: String, enum: ['basic', 'full'], default: 'basic' },
+
+  // Legacy single-score fields. Populated for backwards compatibility even when
+  // dual scoring is enabled — `score` mirrors `aiVisibilityScore`. Historical
+  // reports keep their original values. New code should prefer the dual-score
+  // fields below.
   score: { type: Number, min: 0, max: 100, default: null },
   scoreBreakdown: {
     websiteOptimisation: { type: Number, default: null },
@@ -64,6 +69,15 @@ const aeoReportSchema = new mongoose.Schema({
     structuredData: { type: Number, default: null },
     competitivePosition: { type: Number, default: null },
   },
+
+  // Dual scoring fields (added in the DUAL_SCORING rollout). Null on legacy
+  // reports created before the rollout — frontend renders a banner for those.
+  technicalHealthScore: { type: Number, min: 0, max: 100, default: null },
+  technicalHealthBand: { type: String, default: null },
+  technicalHealthBreakdown: { type: mongoose.Schema.Types.Mixed, default: null },
+  aiVisibilityScore: { type: Number, min: 0, max: 100, default: null },
+  aiVisibilityBand: { type: String, default: null },
+  aiVisibilityBreakdown: { type: mongoose.Schema.Types.Mixed, default: null },
   searchedCompany: {
     website: { type: String, default: null },
     hasReviews: { type: Boolean, default: null },

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -722,11 +722,14 @@ router.get('/all-leads', adminAuth, async (req, res) => {
 /**
  * POST /api/admin/generate-vendor-report
  * Generate a single full AEO visibility report
- * Body: { companyName, category, city, email? }
+ * Body: { companyName, category, city, email?, websiteUrl? }
+ *
+ * websiteUrl drives the deterministic detector that powers dual scoring.
+ * Without it, technicalHealthScore and aiVisibilityScore fall back to null.
  */
 router.post('/generate-vendor-report', adminAuth, async (req, res) => {
   try {
-    const { companyName, category, city, email } = req.body;
+    const { companyName, category, city, email, websiteUrl } = req.body;
 
     if (!companyName || !category || !city) {
       return res.status(400).json({
@@ -755,8 +758,8 @@ router.post('/generate-vendor-report', adminAuth, async (req, res) => {
 
     console.log(`[Admin] Generating full AEO report for "${companyName}" (${category}, ${city})`);
 
-    // 1. Generate report data via Claude
-    const reportData = await generateFullReport({ companyName, category, city, email });
+    // 1. Generate report data via Claude + deterministic dual scoring
+    const reportData = await generateFullReport({ companyName, category, city, email, websiteUrl });
 
     // 2. Generate PDF
     const pdfBuffer = await generateReportPdf(reportData);
@@ -770,12 +773,18 @@ router.post('/generate-vendor-report', adminAuth, async (req, res) => {
     const baseUrl = process.env.FRONTEND_URL || 'https://www.tendorai.com';
     const apiBaseUrl = process.env.API_URL || 'https://ai-procurement-backend.onrender.com';
 
-    console.log(`[Admin] Report generated: ${report._id} — Score: ${report.score}/100`);
+    console.log(
+      `[Admin] Report generated: ${report._id} — Tech: ${report.technicalHealthScore ?? '—'}, AI: ${report.aiVisibilityScore ?? '—'}`,
+    );
 
     res.json({
       success: true,
       reportId: report._id,
       score: report.score,
+      technicalHealthScore: report.technicalHealthScore,
+      technicalHealthBand: report.technicalHealthBand,
+      aiVisibilityScore: report.aiVisibilityScore,
+      aiVisibilityBand: report.aiVisibilityBand,
       aiMentioned: report.aiMentioned,
       competitors: report.competitors?.length || 0,
       gaps: report.gaps?.length || 0,
@@ -820,7 +829,7 @@ router.post('/generate-vendor-reports-batch', adminAuth, async (req, res) => {
     const results = [];
 
     for (let i = 0; i < reports.length; i++) {
-      const { companyName, category, city, email } = reports[i];
+      const { companyName, category, city, email, websiteUrl } = reports[i];
 
       try {
         if (!companyName || !category || !city) {
@@ -830,7 +839,7 @@ router.post('/generate-vendor-reports-batch', adminAuth, async (req, res) => {
 
         console.log(`[Admin Batch] ${i + 1}/${reports.length}: "${companyName}" (${category}, ${city})`);
 
-        const reportData = await generateFullReport({ companyName, category, city, email });
+        const reportData = await generateFullReport({ companyName, category, city, email, websiteUrl });
         const pdfBuffer = await generateReportPdf(reportData);
         const report = await AeoReport.create({ ...reportData, pdfBuffer });
 
@@ -839,6 +848,8 @@ router.post('/generate-vendor-reports-batch', adminAuth, async (req, res) => {
           success: true,
           reportId: report._id,
           score: report.score,
+          technicalHealthScore: report.technicalHealthScore,
+          aiVisibilityScore: report.aiVisibilityScore,
           reportUrl: `${baseUrl}/aeo-report/results/${report._id}`,
           pdfUrl: `${apiBaseUrl}/api/public/aeo-report/${report._id}/pdf`,
         });

--- a/routes/vendorUploadRoutes.js
+++ b/routes/vendorUploadRoutes.js
@@ -1806,23 +1806,26 @@ const rescanLimiter = rateLimit({
 router.post('/aeo-rescan', vendorAuth, rescanLimiter, async (req, res) => {
   try {
     const vendor = await Vendor.findById(req.vendorId)
-      .select('company services location email vendorType practiceAreas')
+      .select('company services location email vendorType practiceAreas contactInfo')
       .lean();
     if (!vendor) return res.status(404).json({ success: false, error: 'Vendor not found' });
 
     const category = getAeoCategory(vendor);
     const city = vendor.location?.city || 'London';
+    const websiteUrl = vendor.contactInfo?.website || undefined;
 
     const report = await generateFullReport({
       companyName: vendor.company,
       category,
       city,
       email: vendor.email,
+      websiteUrl,
     });
 
     // Save the report
     const saved = await AeoReport.create({
       ...report,
+      vendorId: vendor._id,
       ipAddress: req.ip,
     });
 
@@ -1831,6 +1834,12 @@ router.post('/aeo-rescan', vendorAuth, rescanLimiter, async (req, res) => {
       data: {
         reportId: saved._id,
         score: saved.score,
+        technicalHealthScore: saved.technicalHealthScore,
+        technicalHealthBand: saved.technicalHealthBand,
+        technicalHealthBreakdown: saved.technicalHealthBreakdown,
+        aiVisibilityScore: saved.aiVisibilityScore,
+        aiVisibilityBand: saved.aiVisibilityBand,
+        aiVisibilityBreakdown: saved.aiVisibilityBreakdown,
         scoreBreakdown: saved.scoreBreakdown,
         searchedCompany: saved.searchedCompany,
         competitors: saved.competitors,

--- a/scripts/generateBatchReports.js
+++ b/scripts/generateBatchReports.js
@@ -176,9 +176,11 @@ async function main() {
   }
 
   const isProfType = ['solicitor', 'accountant', 'mortgage-advisor', 'estate-agent'].includes(filterVendorType);
+  // contactInfo.website drives the deterministic detector that powers dual
+  // scoring — without it, technicalHealthScore / aiVisibilityScore are null.
   const selectFields = isProfType
-    ? 'company email practiceAreas location vendorType'
-    : 'company email services location vendorType practiceAreas';
+    ? 'company email practiceAreas location vendorType contactInfo'
+    : 'company email services location vendorType practiceAreas contactInfo';
 
   const vendors = await Vendor.find(query)
     .select(selectFields)
@@ -226,14 +228,17 @@ async function main() {
     console.log(`[${i + 1}/${toProcess.length}] "${companyName}" — ${category} — ${city} (${vendor.vendorType || 'equipment'})`);
 
     try {
-      const reportData = await generateFullReport({ companyName, category, city, email });
+      const websiteUrl = vendor.contactInfo?.website || undefined;
+      const reportData = await generateFullReport({ companyName, category, city, email, websiteUrl });
       const pdfBuffer = await generateReportPdf(reportData);
       const report = await AeoReport.create({ ...reportData, pdfBuffer });
 
       const reportUrl = `${FRONTEND_URL}/aeo-report/results/${report._id}`;
       const pdfUrl = `${API_URL}/api/public/aeo-report/${report._id}/pdf`;
 
-      console.log(`  Score: ${report.score}/100 | Competitors: ${report.competitors?.length || 0}`);
+      console.log(
+        `  Tech: ${report.technicalHealthScore ?? '—'}/100 | AI: ${report.aiVisibilityScore ?? '—'}/100 | Legacy: ${report.score}/100 | Competitors: ${report.competitors?.length || 0}`,
+      );
       console.log(`  URL: ${reportUrl}`);
 
       const escCsv = (s) => {

--- a/scripts/testReportGeneration.js
+++ b/scripts/testReportGeneration.js
@@ -27,11 +27,15 @@ if (!process.env.ANTHROPIC_API_KEY) {
 const FRONTEND_URL = process.env.FRONTEND_URL || 'https://www.tendorai.com';
 const API_URL = process.env.API_URL || 'https://ai-procurement-backend.onrender.com';
 
+// websiteUrl drives the deterministic detector that powers dual scoring.
+// Populate with the company's real homepage to exercise Technical Health
+// and AI Visibility end-to-end. Leaving it null exercises only the LLM
+// summary + competitor pipeline; dual-score fields will come back null.
 const testCompanies = [
-  { companyName: 'Solutions in Technology', category: 'copiers', city: 'Cwmbran' },
-  { companyName: 'Clarity Copiers', category: 'copiers', city: 'Bristol' },
-  { companyName: 'Ogi', category: 'telecoms', city: 'Cardiff' },
-  { companyName: 'Made Up Company Ltd', category: 'it', city: 'London' },
+  { companyName: 'Solutions in Technology', category: 'copiers', city: 'Cwmbran', websiteUrl: null },
+  { companyName: 'Clarity Copiers', category: 'copiers', city: 'Bristol', websiteUrl: null },
+  { companyName: 'Ogi', category: 'telecoms', city: 'Cardiff', websiteUrl: null },
+  { companyName: 'Made Up Company Ltd', category: 'it', city: 'London', websiteUrl: null },
 ];
 
 async function main() {
@@ -64,20 +68,25 @@ async function main() {
       const pdfUrl = `${API_URL}/api/public/aeo-report/${report._id}/pdf`;
 
       console.log('\n--- RESULTS ---');
-      console.log(`Report ID:    ${report._id}`);
-      console.log(`Score:        ${report.score}/100 (${report.score <= 30 ? 'RED' : report.score <= 60 ? 'AMBER' : 'BLUE'})`);
-      console.log(`AI Mentioned: ${report.aiMentioned} ${report.aiPosition ? `(position ${report.aiPosition})` : ''}`);
-      console.log(`Competitors:  ${report.competitors.length}`);
+      console.log(`Report ID:        ${report._id}`);
+      console.log(`Technical Health: ${report.technicalHealthScore ?? '—'}/100${report.technicalHealthBand ? ` (${report.technicalHealthBand})` : ''}`);
+      console.log(`AI Visibility:    ${report.aiVisibilityScore ?? '—'}/100${report.aiVisibilityBand ? ` (${report.aiVisibilityBand})` : ''}`);
+      console.log(`Legacy score:     ${report.score ?? '—'}/100`);
+      console.log(`AI Mentioned:     ${report.aiMentioned} ${report.aiPosition ? `(position ${report.aiPosition})` : ''}`);
+      console.log(`Competitors:      ${report.competitors.length}`);
       report.competitors.forEach((c, j) => {
         console.log(`  ${j + 1}. ${c.name} — ${c.website || 'no URL'}`);
       });
-      console.log(`Gaps:         ${report.gaps.length}`);
+      console.log(`Gaps:             ${report.gaps.length}`);
       report.gaps.forEach((g, j) => {
         console.log(`  ${j + 1}. ${g.title}`);
       });
-      console.log(`Web URL:      ${reportUrl}`);
-      console.log(`PDF URL:      ${pdfUrl}`);
-      console.log(`Breakdown:    website=${reportData.scoreBreakdown.websiteOptimisation} content=${reportData.scoreBreakdown.contentAuthority} directory=${reportData.scoreBreakdown.directoryPresence} reviews=${reportData.scoreBreakdown.reviewSignals} schema=${reportData.scoreBreakdown.structuredData} competitive=${reportData.scoreBreakdown.competitivePosition}`);
+      console.log(`Web URL:          ${reportUrl}`);
+      console.log(`PDF URL:          ${pdfUrl}`);
+      if (reportData.scoreBreakdown) {
+        const sb = reportData.scoreBreakdown;
+        console.log(`Legacy breakdown: website=${sb.websiteOptimisation} content=${sb.contentAuthority} directory=${sb.directoryPresence} reviews=${sb.reviewSignals} schema=${sb.structuredData} competitive=${sb.competitivePosition}`);
+      }
 
     } catch (err) {
       console.error(`FAILED: ${err.message}`);

--- a/services/aeoDetector.js
+++ b/services/aeoDetector.js
@@ -334,6 +334,7 @@ export function analyseAeoSignals(html, url) {
   // 1. Schema.org structured data
   const ldJsonMatches = html.match(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi) || [];
   const schemaCount = ldJsonMatches.length;
+  const jsonLdPayloads = parseJsonLdPayloads(ldJsonMatches);
   const schemaScore = schemaCount >= 3 ? 10 : schemaCount === 2 ? 8 : schemaCount === 1 ? 5 : 0;
   checks.push({
     name: 'Schema.org Structured Data',
@@ -513,7 +514,39 @@ export function analyseAeoSignals(html, url) {
       /src=["'][^"']*tendorai\.com[^"']*schema/i.test(html);
   }
 
-  return { overallScore, checks, recommendations, tendoraiSchemaDetected };
+  return { overallScore, checks, recommendations, tendoraiSchemaDetected, jsonLdPayloads };
+}
+
+/**
+ * Parse raw <script type="application/ld+json"> blocks into plain objects.
+ * Tolerant: malformed blocks are skipped. @graph arrays are flattened so
+ * each top-level entity appears as its own payload. Always returns an array.
+ */
+export function parseJsonLdPayloads(ldJsonMatches) {
+  const out = [];
+  for (const block of ldJsonMatches || []) {
+    const inner = block.replace(/^<script[^>]*>/i, '').replace(/<\/script>$/i, '').trim();
+    if (!inner) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(inner);
+    } catch {
+      continue;
+    }
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    for (const item of items) {
+      if (item && typeof item === 'object') {
+        if (Array.isArray(item['@graph'])) {
+          for (const sub of item['@graph']) {
+            if (sub && typeof sub === 'object') out.push(sub);
+          }
+        } else {
+          out.push(item);
+        }
+      }
+    }
+  }
+  return out;
 }
 
 /**
@@ -566,7 +599,7 @@ export async function runDetector({ websiteUrl }) {
   const blogDetection = await detectBlog(origin, html);
   const hasPricing = await checkPricing(origin, html);
   const hasDetailedServices = await checkDetailedServices(origin, html);
-  const { overallScore, checks, recommendations, tendoraiSchemaDetected } = analyseAeoSignals(html, url);
+  const { overallScore, checks, recommendations, tendoraiSchemaDetected, jsonLdPayloads } = analyseAeoSignals(html, url);
 
   return {
     websiteUrl: url,
@@ -577,5 +610,6 @@ export async function runDetector({ websiteUrl }) {
     hasPricing,
     hasDetailedServices,
     tendoraiSchemaDetected,
+    jsonLdPayloads,
   };
 }

--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -418,6 +418,14 @@ function getVendorType(category) {
 
 // ─── Build the checklist section of the prompt per vendorType ─────────────────
 
+// Note on hasBrands: this remains an LLM judgement and is not overridden by
+// the deterministic detector. Accreditations (SRA, ICAEW, FCA, Propertymark,
+// Lexcel, …) live in copy, badge images, and footer text that scraping
+// cannot reliably parse — a missed footer logo or non-standard wording
+// flips the boolean wrongly. The LLM, with web search, makes a better call
+// here than a regex would. The other booleans on this checklist
+// (hasStructuredData, hasSocialMedia, hasPricing, hasDetailedServices) are
+// overridden post-LLM with detector output where available.
 function getChecklistPrompt(vendorType) {
   if (vendorType === 'solicitor') {
     return `  "searchedCompany": {

--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -9,7 +9,19 @@
  */
 
 import Vendor from '../models/Vendor.js';
-import { checkGoogleBusinessProfile, checkGoogleReviews } from './googleBusinessProfile.js';
+import {
+  checkGoogleBusinessProfile,
+  checkGoogleReviews,
+  checkPlacesListingQuality,
+} from './googleBusinessProfile.js';
+import { runDetector } from './aeoDetector.js';
+import { queryAllPlatforms } from './platformQuery/index.js';
+import {
+  computeTechnicalHealth,
+  computeAiVisibility,
+  isDualScoringEnabled,
+} from './scoring.js';
+import { mapScoreBreakdown } from './publicAeoReportBuilder.js';
 
 // ─── Category labels (human-readable) ────────────────────────────────────────
 
@@ -477,109 +489,9 @@ function getChecklistPrompt(vendorType) {
   }`;
 }
 
-// ─── Scoring hints per vendorType ────────────────────────────────────────────
-
-function getScoringHints(vendorType) {
-  if (vendorType === 'solicitor') {
-    return `SCORING RULES:
-- score is 0-100 overall AI visibility score
-- Each scoreBreakdown sub-score is 0-17 (they should roughly sum to the overall score)
-- websiteOptimisation: Does the site have good meta tags, speed, mobile-friendly, schema markup (LegalService)?
-- contentAuthority: Does the firm have authoritative content — legal guides, blog posts, case studies, FAQ pages?
-- directoryPresence: Is the firm on the SRA register, Law Society Find a Solicitor, legal directories (Chambers, Legal 500), Google Business?
-- reviewSignals: Google reviews, Trustpilot, ReviewSolicitors, client testimonials?
-- structuredData: Schema.org/LegalService markup, JSON-LD, LocalBusiness structured data?
-- competitivePosition: How visible are they vs other solicitors in the area? Would AI recommend them?`;
-  }
-
-  if (vendorType === 'accountant') {
-    return `SCORING RULES:
-- score is 0-100 overall AI visibility score
-- Each scoreBreakdown sub-score is 0-17 (they should roughly sum to the overall score)
-- websiteOptimisation: Does the site have good meta tags, speed, mobile-friendly, schema markup (AccountingService)?
-- contentAuthority: Does the firm have authoritative content — tax guides, blog posts, case studies, FAQ pages?
-- directoryPresence: Is the firm on the ICAEW directory, ACCA directory, Google Business, accountancy directories?
-- reviewSignals: Google reviews, Trustpilot, client testimonials?
-- structuredData: Schema.org/AccountingService markup, JSON-LD, LocalBusiness structured data?
-- competitivePosition: How visible are they vs other accountants in the area? Would AI recommend them?`;
-  }
-
-  if (vendorType === 'mortgage-advisor') {
-    return `SCORING RULES:
-- score is 0-100 overall AI visibility score
-- Each scoreBreakdown sub-score is 0-17 (they should roughly sum to the overall score)
-- websiteOptimisation: Does the site have good meta tags, speed, mobile-friendly, schema markup (FinancialService)?
-- contentAuthority: Does the firm have authoritative content — mortgage guides, blog posts, calculators, FAQ pages?
-- directoryPresence: Is the firm on the FCA register, VouchedFor, Unbiased, Google Business?
-- reviewSignals: Google reviews, Trustpilot, VouchedFor ratings, client testimonials?
-- structuredData: Schema.org/FinancialService markup, JSON-LD, LocalBusiness structured data?
-- competitivePosition: How visible are they vs other mortgage advisors in the area? Would AI recommend them? Weight FCA authorisation status, lender panel breadth, and review volume heavily.`;
-  }
-
-  if (vendorType === 'estate-agent') {
-    return `SCORING RULES:
-- score is 0-100 overall AI visibility score
-- Each scoreBreakdown sub-score is 0-17 (they should roughly sum to the overall score)
-- websiteOptimisation: Does the site have good meta tags, speed, mobile-friendly, schema markup (RealEstateAgent)?
-- contentAuthority: Does the agency have authoritative content — area guides, market reports, blog posts, sold price data?
-- directoryPresence: Is the agency on Rightmove, Zoopla, OnTheMarket, Propertymark directory, Google Business?
-- reviewSignals: Google reviews, Trustpilot, AllAgents, Rightmove reviews, client testimonials?
-- structuredData: Schema.org/RealEstateAgent markup, JSON-LD, LocalBusiness structured data?
-- competitivePosition: How visible are they vs other agents in the area? Would AI recommend them? Weight Propertymark membership, portal listing presence, and sold price track record heavily.`;
-  }
-
-  // Default: office equipment
-  return `SCORING RULES:
-- score is 0-100 overall AI visibility score
-- Each scoreBreakdown sub-score is 0-17 (they should roughly sum to the overall score)
-- websiteOptimisation: Does the site have good meta tags, speed, mobile-friendly, schema markup?
-- contentAuthority: Does the company have authoritative content, blog posts, case studies?
-- directoryPresence: Is the company listed on relevant directories, Google Business, Yell, etc?
-- reviewSignals: Google reviews, Trustpilot, industry-specific review sites?
-- structuredData: Schema.org markup, JSON-LD, structured data on their website?
-- competitivePosition: How visible are they vs competitors? Are they the go-to recommendation?`;
-}
-
-// ─── Gap hints per vendorType ────────────────────────────────────────────────
-
-function getGapHints(vendorType) {
-  if (vendorType === 'solicitor') {
-    return `GAP RULES:
-- Return 3-5 specific, actionable gaps
-- Focus on things the firm is missing that competing solicitors have
-- Common solicitor gaps: no SRA-linked website, no legal directory listings, no client testimonials, no detailed practice area pages, no fee transparency, no schema markup, no blog/legal guides
-- Be specific: "No visible client reviews on Google" not "Poor online presence"`;
-  }
-
-  if (vendorType === 'accountant') {
-    return `GAP RULES:
-- Return 3-5 specific, actionable gaps
-- Focus on things the firm is missing that competing accountants have
-- Common accountant gaps: no ICAEW directory link, no client testimonials, no detailed service pages, no fee transparency, no schema markup, no blog/tax guides, no cloud accounting partner badges (Xero/QuickBooks)
-- Be specific: "No visible client reviews on Google" not "Poor online presence"`;
-  }
-
-  if (vendorType === 'mortgage-advisor') {
-    return `GAP RULES:
-- Return 3-5 specific, actionable gaps
-- Focus on things the firm is missing that competing mortgage advisors have
-- Common mortgage advisor gaps: no FCA register link on website, no lender panel information, no fee disclosure page, no mortgage calculators, no FinancialService schema markup, no VouchedFor/Unbiased profile, no blog/mortgage guides, no CeMAP/DipFA qualification display, unclear whole-of-market vs restricted status
-- Be specific: "No FCA registration number visible on website" not "Poor compliance"`;
-  }
-
-  if (vendorType === 'estate-agent') {
-    return `GAP RULES:
-- Return 3-5 specific, actionable gaps
-- Focus on things the agency is missing that competing estate agents have
-- Common estate agent gaps: no Propertymark/NAEA membership displayed, no Rightmove/Zoopla presence, no sold price data or track record, no RealEstateAgent schema markup, no area guides, no complaints procedure page, no client money protection details, no Instagram/social media property marketing, no virtual tour capability
-- Be specific: "No sold prices or market track record visible on website" not "Poor online presence"`;
-  }
-
-  return `GAP RULES:
-- Return 3-5 specific, actionable gaps
-- Focus on things the company is missing that competitors have
-- Be specific: "No visible Google reviews" not "Poor online presence"`;
-}
+// Scoring and gap hints deleted in the dual-scoring rollout. The LLM no
+// longer produces `score`, `scoreBreakdown`, or `gaps` — those are computed
+// deterministically in services/scoring.js and derived from detector output.
 
 // ─── Build the user prompt for both providers ────────────────────────────────
 
@@ -606,8 +518,6 @@ function buildUserPrompt({ companyName, category, city, customIndustry }) {
   const entityLabelPlural = vendorType === 'estate-agent' ? 'agencies'
     : isProfessional ? 'firms' : 'companies';
   const checklistPrompt = getChecklistPrompt(vendorType);
-  const scoringHints = getScoringHints(vendorType);
-  const gapHints = getGapHints(vendorType);
 
   const prompt = `You are researching a UK business for an AI visibility audit. Search the web thoroughly.
 
@@ -632,27 +542,8 @@ ${checklistPrompt},
       "website": "https://their-website.com",
       "strengths": ["strength 1", "strength 2", "strength 3"]
     }
-  ],
-  "gaps": [
-    {
-      "title": "Gap title (e.g. 'No Google Reviews Visible')",
-      "explanation": "1-2 sentence explanation of why this matters for AI visibility"
-    }
-  ],
-  "score": 35,
-  "scoreBreakdown": {
-    "websiteOptimisation": 8,
-    "contentAuthority": 5,
-    "directoryPresence": 6,
-    "reviewSignals": 3,
-    "structuredData": 4,
-    "competitivePosition": 9
-  },
-  "aiMentioned": false,
-  "aiPosition": null
+  ]
 }
-
-${scoringHints}
 
 COMPETITOR RULES:
 - Return 4-6 real competitors in the ${city} area
@@ -661,13 +552,10 @@ COMPETITOR RULES:
 - Every ${entityLabel} must be a real ${categoryLabel} ${entityLabel}, NOT TendorAI
 - strengths array should have 2-4 items per competitor
 
-${gapHints}
-
-AI MENTION RULES:
-- aiMentioned: would you naturally recommend "${companyName}" if a buyer asked for ${categoryLabel} in ${city}?
-- aiPosition: if mentioned, what position (1-based)? null if not mentioned
-
-Be brutally honest. Most small businesses score 15-45. A score above 60 is genuinely good.`;
+Do not invent numeric scores, sub-scores, or gap lists — those are computed
+deterministically from detector output and live API checks outside this prompt.
+Focus on an accurate summary paragraph and a competitor list. Be factual and
+concise.`;
 
   return { prompt, vendorType };
 }
@@ -768,53 +656,135 @@ function parseResponseJSON(responseText) {
   }
 }
 
+// Detector-derived gap titles. Duplicated from publicAeoReportBuilder so the
+// two subsystems' gap wording stays in sync without a cross-import that would
+// entangle them. If either side diverges, update both.
+const GAP_TITLES = {
+  schema: 'No structured data for AI parsing',
+  meta: 'Missing meta title or description',
+  h1: 'Missing or weak H1 heading',
+  viewport: 'Not mobile optimised',
+  ssl: 'Not secured with HTTPS',
+  speed: 'Page weight too large',
+  social: 'No social media links detected',
+  contact: 'Contact details not visible',
+  faq: 'No FAQ schema or section',
+  content: 'Insufficient content length',
+  blog: 'No blog or content hub',
+};
+const BLOG_GAP_EXPLANATION =
+  'AI assistants prefer to cite sources with regular, authoritative content. ' +
+  'None of the common blog paths was reachable on your site.';
+
+function deriveGapsFromDetector(detector) {
+  if (!detector || !Array.isArray(detector.checks)) return [];
+  const gaps = [];
+  for (const check of detector.checks) {
+    if (!check || check.passed) continue;
+    const max = check.maxScore ?? 10;
+    const score = check.score ?? 0;
+    gaps.push({
+      key: check.key,
+      title: GAP_TITLES[check.key] || check.name || 'Visibility gap',
+      explanation: check.recommendation || '',
+      impact: max - score,
+    });
+  }
+  if (detector.blogDetection && !detector.blogDetection.hasBlog) {
+    gaps.push({
+      key: 'blog',
+      title: GAP_TITLES.blog,
+      explanation: BLOG_GAP_EXPLANATION,
+      impact: 10,
+    });
+  }
+  gaps.sort((a, b) => b.impact - a.impact);
+  return gaps.slice(0, 5).map(({ title, explanation }) => ({ title, explanation }));
+}
+
 /**
  * Generate a full AEO visibility report for a company.
  *
+ * The LLM is now used only for:
+ *   - searchedCompany.summary (narrative paragraph)
+ *   - competitors array
+ *
+ * All scoring (Technical Health, AI Visibility), searchedCompany booleans,
+ * GBP/reviews/Places listing, AI platform mentions, and gaps are computed
+ * deterministically from the detector + live API checks. The LLM no longer
+ * produces `score`, `scoreBreakdown`, or `gaps`.
+ *
+ * When websiteUrl is omitted the detector is skipped — dual scoring and
+ * detector-derived gaps are null. Callers in the rescan flows plumb
+ * websiteUrl through so production paths always get full dual scoring.
+ *
  * @param {Object} params
  * @param {string} params.companyName
- * @param {string} params.category - copiers|telecoms|cctv|it|conveyancing|family-law|...
+ * @param {string} params.category - copiers|telecoms|cctv|it|conveyancing|...
  * @param {string} params.city
  * @param {string} [params.email]
+ * @param {string} [params.customIndustry]
+ * @param {string} [params.websiteUrl] - drives the deterministic detector
  * @returns {Object} Full report data ready for saving
  */
-export async function generateFullReport({ companyName, category, city, email, customIndustry }) {
+export async function generateFullReport({
+  companyName,
+  category,
+  city,
+  email,
+  customIndustry,
+  websiteUrl,
+}) {
   if (!process.env.ANTHROPIC_API_KEY && !process.env.OPENAI_API_KEY) {
     throw new Error('Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is configured');
   }
 
   const { prompt: userPrompt, vendorType } = buildUserPrompt({ companyName, category, city, customIndustry });
+  const categoryLabel = customIndustry || CATEGORY_LABELS[category] || category;
 
-  // Try Claude first, fall back to OpenAI
-  let responseText;
-  if (process.env.ANTHROPIC_API_KEY) {
-    try {
-      responseText = await generateWithClaude(userPrompt);
-    } catch (claudeErr) {
-      console.error('[AEO] Claude failed, falling back to OpenAI:', claudeErr.message);
-      if (!process.env.OPENAI_API_KEY) {
-        throw new Error('Claude failed and OPENAI_API_KEY is not configured as fallback');
+  // Fire the slow I/O — LLM + detector + platform queries — in parallel so
+  // the rescan latency doesn't sum. GBP/reviews/places share a cache and
+  // are cheap; we run them serially after the detector returns.
+  const llmPromise = (async () => {
+    if (process.env.ANTHROPIC_API_KEY) {
+      try {
+        return await generateWithClaude(userPrompt);
+      } catch (claudeErr) {
+        console.error('[AEO] Claude failed, falling back to OpenAI:', claudeErr.message);
+        if (!process.env.OPENAI_API_KEY) {
+          throw new Error('Claude failed and OPENAI_API_KEY is not configured as fallback');
+        }
+        return await generateWithOpenAI(userPrompt);
       }
-      responseText = await generateWithOpenAI(userPrompt);
     }
-  } else {
     console.log('[AEO] No ANTHROPIC_API_KEY, using OpenAI directly');
-    responseText = await generateWithOpenAI(userPrompt);
-  }
+    return generateWithOpenAI(userPrompt);
+  })();
+
+  const detectorPromise = websiteUrl
+    ? runDetector({ websiteUrl }).catch((err) => {
+        console.warn(`[AEO] Detector failed for "${websiteUrl}": ${err.message}`);
+        return { fetchError: err.message };
+      })
+    : Promise.resolve(null);
+
+  const platformPromise = queryAllPlatforms({
+    companyName,
+    category,
+    city,
+    categoryLabel,
+  }).catch((err) => {
+    console.error('[AEO] Platform queries failed:', err.message);
+    return [];
+  });
+
+  const [responseText, detectorRaw, platformResults] = await Promise.all([
+    llmPromise,
+    detectorPromise,
+    platformPromise,
+  ]);
 
   const parsed = parseResponseJSON(responseText);
-
-  // Validate and clamp score
-  const score = Math.max(0, Math.min(100, Math.round(parsed.score || 0)));
-
-  const scoreBreakdown = {
-    websiteOptimisation: clamp(parsed.scoreBreakdown?.websiteOptimisation, 0, 17),
-    contentAuthority: clamp(parsed.scoreBreakdown?.contentAuthority, 0, 17),
-    directoryPresence: clamp(parsed.scoreBreakdown?.directoryPresence, 0, 17),
-    reviewSignals: clamp(parsed.scoreBreakdown?.reviewSignals, 0, 17),
-    structuredData: clamp(parsed.scoreBreakdown?.structuredData, 0, 17),
-    competitivePosition: clamp(parsed.scoreBreakdown?.competitivePosition, 0, 17),
-  };
 
   const competitors = (parsed.competitors || []).map((c) => ({
     name: c.name || 'Unknown',
@@ -824,13 +794,8 @@ export async function generateFullReport({ companyName, category, city, email, c
     strengths: Array.isArray(c.strengths) ? c.strengths.slice(0, 5) : [],
   }));
 
-  const gaps = (parsed.gaps || []).map((g) => ({
-    title: g.title || 'Unknown Gap',
-    explanation: g.explanation || '',
-  }));
-
   const searchedCompany = {
-    website: parsed.searchedCompany?.website || null,
+    website: parsed.searchedCompany?.website || websiteUrl || null,
     hasReviews: !!parsed.searchedCompany?.hasReviews,
     hasPricing: !!parsed.searchedCompany?.hasPricing,
     hasBrands: !!parsed.searchedCompany?.hasBrands,
@@ -841,20 +806,33 @@ export async function generateFullReport({ companyName, category, city, email, c
     summary: parsed.searchedCompany?.summary || null,
   };
 
-  // Override the LLM's hasGoogleBusiness guess with a real Places API lookup.
-  // On any failure, leave the LLM value intact so the rescan still completes.
+  // Detector built? Prefer its deterministic findings over the LLM's guesses
+  // for the boolean checks we can actually measure.
+  const detectorUsable = !!(detectorRaw && !detectorRaw.fetchError && Array.isArray(detectorRaw.checks));
+  if (detectorUsable) {
+    const byKey = Object.create(null);
+    for (const c of detectorRaw.checks) byKey[c.key] = c;
+    searchedCompany.hasStructuredData = byKey.schema?.passed ?? searchedCompany.hasStructuredData;
+    searchedCompany.hasSocialMedia = byKey.social?.passed ?? searchedCompany.hasSocialMedia;
+    if (typeof detectorRaw.hasPricing === 'boolean') searchedCompany.hasPricing = detectorRaw.hasPricing;
+    if (typeof detectorRaw.hasDetailedServices === 'boolean') {
+      searchedCompany.hasDetailedServices = detectorRaw.hasDetailedServices;
+    }
+  }
+
+  // GBP / reviews / Places listing — shared cache, so three checks = one API call.
+  let gbp = null;
+  let reviews = null;
+  let placesListing = null;
   try {
-    const gbp = await checkGoogleBusinessProfile(companyName, city);
+    gbp = await checkGoogleBusinessProfile(companyName, city);
     searchedCompany.hasGoogleBusiness = gbp.state === 'pass' || gbp.state === 'amber';
     searchedCompany.googleBusinessDetail = { state: gbp.state, summary: gbp.summary };
   } catch (err) {
     console.warn(`[AEO] GBP override failed for "${companyName}" in "${city}": ${err.message}`);
   }
-
-  // Override the LLM's hasReviews guess with a real Places reviews lookup.
-  // Reuses the GBP lookup cache, so this costs zero extra Places calls.
   try {
-    const reviews = await checkGoogleReviews(companyName, city);
+    reviews = await checkGoogleReviews(companyName, city);
     searchedCompany.hasReviews = reviews.state === 'pass';
     searchedCompany.reviewsDetail = {
       state: reviews.state,
@@ -865,8 +843,41 @@ export async function generateFullReport({ companyName, category, city, email, c
   } catch (err) {
     console.warn(`[AEO] Reviews override failed for "${companyName}" in "${city}": ${err.message}`);
   }
+  try {
+    placesListing = await checkPlacesListingQuality(companyName, city, vendorType);
+  } catch (err) {
+    console.warn(`[AEO] Places listing check failed for "${companyName}" in "${city}": ${err.message}`);
+  }
 
-  // Build backward-compatible aiRecommendations array
+  // Dual scoring. Flag default TRUE — DUAL_SCORING=false in Render env reverts
+  // responses to legacy single-score shape for rollback without a redeploy.
+  const dualEnabled = isDualScoringEnabled();
+  let techResult = null;
+  let aiResult = null;
+  if (dualEnabled && detectorUsable) {
+    const detectorForScoring = {
+      ...detectorRaw,
+      jsonLdPayloads: detectorRaw.jsonLdPayloads || [],
+    };
+    techResult = computeTechnicalHealth(detectorForScoring);
+    aiResult = computeAiVisibility(detectorForScoring, gbp, reviews, placesListing, platformResults);
+  }
+
+  const gaps = deriveGapsFromDetector(detectorRaw);
+
+  // aiMentioned / aiPosition: prefer real platformQuery data, fall back to
+  // the LLM's own boolean only if platform queries returned nothing useful.
+  let aiMentioned = null;
+  let aiPosition = null;
+  if (Array.isArray(platformResults) && platformResults.length > 0) {
+    aiMentioned = platformResults.some((p) => p.mentioned === true);
+    const firstHit = platformResults.find((p) => p.mentioned === true);
+    aiPosition = firstHit?.position ?? null;
+  } else {
+    aiMentioned = !!parsed.aiMentioned;
+    aiPosition = parsed.aiPosition || null;
+  }
+
   const aiRecommendations = competitors.map((c) => ({
     name: c.name,
     description: c.description,
@@ -878,7 +889,6 @@ export async function generateFullReport({ companyName, category, city, email, c
   const cityRegex = new RegExp(city, 'i');
 
   if (category === 'other') {
-    // No TendorAI directory for 'other' categories
     competitorsOnTendorAI = 0;
   } else if (vendorType === 'solicitor' || vendorType === 'accountant' || vendorType === 'mortgage-advisor' || vendorType === 'estate-agent') {
     const practiceArea = CATEGORY_TO_PRACTICE_AREA[category];
@@ -898,26 +908,68 @@ export async function generateFullReport({ companyName, category, city, email, c
     });
   }
 
-  return {
+  // Persisted detectorResult mirrors the public builder's shape — jsonLdPayloads
+  // stays off the sub-doc (feed-through only, not a persisted field).
+  const detectorResult = detectorUsable
+    ? {
+        websiteUrl: detectorRaw.websiteUrl,
+        overallScore: detectorRaw.overallScore,
+        checks: detectorRaw.checks,
+        blogDetection: detectorRaw.blogDetection,
+        hasPricing: detectorRaw.hasPricing ?? null,
+        hasDetailedServices: detectorRaw.hasDetailedServices ?? null,
+        tendoraiSchemaDetected: detectorRaw.tendoraiSchemaDetected,
+        fetchError: null,
+        runAt: new Date(),
+      }
+    : undefined;
+
+  // Legacy `score` mirrors aiVisibilityScore when dual scoring is on; falls
+  // back to the detector's /100 sum so the frontend always has a number.
+  // When the detector didn't run and dual scoring is off, legacy score is null.
+  let legacyScore = null;
+  if (dualEnabled && aiResult?.score != null) {
+    legacyScore = aiResult.score;
+  } else if (detectorUsable) {
+    legacyScore = detectorRaw.overallScore;
+  }
+
+  // Legacy 6-bucket scoreBreakdown kept populated for backwards compat —
+  // the existing PDF renderer still reads it. Sourced from detector +
+  // platformResults, same shape as the public builder produces. Null when
+  // the detector didn't run.
+  const scoreBreakdown = detectorUsable
+    ? mapScoreBreakdown(detectorResult, platformResults)
+    : null;
+
+  const result = {
     companyName,
     category,
     customIndustry: customIndustry || null,
     city,
     email: email || undefined,
     reportType: 'full',
-    aiMentioned: !!parsed.aiMentioned,
-    aiPosition: parsed.aiPosition || null,
+    aiMentioned,
+    aiPosition,
     aiRecommendations,
     competitorsOnTendorAI,
-    score,
+    score: legacyScore,
     scoreBreakdown,
     searchedCompany,
     competitors,
     gaps,
+    platformResults,
+    detectorResult,
   };
-}
 
-function clamp(val, min, max) {
-  if (val == null || isNaN(val)) return 0;
-  return Math.max(min, Math.min(max, Math.round(val)));
+  if (dualEnabled) {
+    result.technicalHealthScore = techResult?.score ?? null;
+    result.technicalHealthBand = techResult?.band ?? null;
+    result.technicalHealthBreakdown = techResult?.breakdown ?? null;
+    result.aiVisibilityScore = aiResult?.score ?? null;
+    result.aiVisibilityBand = aiResult?.band ?? null;
+    result.aiVisibilityBreakdown = aiResult?.breakdown ?? null;
+  }
+
+  return result;
 }

--- a/services/googleBusinessProfile.js
+++ b/services/googleBusinessProfile.js
@@ -19,6 +19,7 @@ const FIELD_MASK = [
   'places.photos',
   'places.shortFormattedAddress',
   'places.primaryType',
+  'places.types',
   'places.businessStatus',
   'places.rating',
   'places.userRatingCount',
@@ -251,6 +252,87 @@ export async function checkGoogleReviews(companyName, city) {
     summary: 'Fewer than 3 Google reviews — ask customers to leave a review',
     rating: rating ?? undefined,
     count,
+  };
+}
+
+// Vendor-type → Google Places type values we consider a category match.
+// Kept in this module so Places-specific strings don't leak into scoring logic.
+// Any vendor type not in this table resolves to 'skipped' — callers redistribute
+// those points across other AI Visibility signals.
+const VENDOR_TYPE_TO_PLACES_TYPES = Object.freeze({
+  solicitor: ['lawyer', 'legal_services'],
+  accountant: ['accounting'],
+  'mortgage-advisor': ['finance', 'insurance_agency'],
+  'estate-agent': ['real_estate_agency'],
+});
+
+const LISTING_SKIPPED_RESULT = Object.freeze({
+  state: 'skipped',
+  summary: 'Places category check not applicable for this vendor type',
+});
+const LISTING_UNAVAILABLE_RESULT = Object.freeze({
+  state: 'fail',
+  summary: 'Places listing check temporarily unavailable',
+});
+const LISTING_NO_MATCH_RESULT = Object.freeze({
+  state: 'fail',
+  summary: 'No matching Google Places listing found',
+});
+
+/**
+ * Grade the Google Places listing for category alignment. Reuses the shared
+ * lookupPlace cache — costs zero extra Places API calls when GBP/Reviews
+ * already ran for this company+city.
+ *
+ * @param {string} companyName
+ * @param {string} city
+ * @param {string} expectedVendorType - 'solicitor' | 'accountant' |
+ *   'mortgage-advisor' | 'estate-agent'. Any other value resolves to 'skipped'.
+ * @returns {Promise<{state: 'pass' | 'amber' | 'fail' | 'skipped', summary: string, primaryType?: string, types?: string[]}>}
+ */
+export async function checkPlacesListingQuality(companyName, city, expectedVendorType) {
+  const expectedTypes = VENDOR_TYPE_TO_PLACES_TYPES[expectedVendorType];
+  if (!Array.isArray(expectedTypes) || expectedTypes.length === 0) {
+    return LISTING_SKIPPED_RESULT;
+  }
+  if (!companyName || !city) return LISTING_NO_MATCH_RESULT;
+
+  const lookup = await lookupPlace(companyName, city);
+  if (lookup.status === 'unavailable') return LISTING_UNAVAILABLE_RESULT;
+  if (!lookup.place) return LISTING_NO_MATCH_RESULT;
+
+  const place = lookup.place;
+  const primaryType = typeof place.primaryType === 'string' ? place.primaryType : null;
+  const types = Array.isArray(place.types)
+    ? place.types.filter((t) => typeof t === 'string')
+    : [];
+
+  if (primaryType && expectedTypes.includes(primaryType)) {
+    return {
+      state: 'pass',
+      summary: `Listing primary category is "${primaryType}"`,
+      primaryType,
+      types,
+    };
+  }
+
+  const typeHit = types.find((t) => expectedTypes.includes(t));
+  if (typeHit) {
+    return {
+      state: 'amber',
+      summary: `Listing carries "${typeHit}" but primary category is ${primaryType ? `"${primaryType}"` : 'generic'}`,
+      primaryType,
+      types,
+    };
+  }
+
+  return {
+    state: 'fail',
+    summary: primaryType
+      ? `Listing is categorised "${primaryType}" — does not match expected vendor type`
+      : 'Listing has no category that matches expected vendor type',
+    primaryType,
+    types,
   };
 }
 

--- a/services/publicAeoReportBuilder.js
+++ b/services/publicAeoReportBuilder.js
@@ -13,7 +13,16 @@
 import { runDetector } from './aeoDetector.js';
 import { queryAllPlatforms } from './platformQuery/index.js';
 import { isValidBusinessName } from './platformQuery/prompt.js';
-import { checkGoogleBusinessProfile, checkGoogleReviews } from './googleBusinessProfile.js';
+import {
+  checkGoogleBusinessProfile,
+  checkGoogleReviews,
+  checkPlacesListingQuality,
+} from './googleBusinessProfile.js';
+import {
+  computeTechnicalHealth,
+  computeAiVisibility,
+  isDualScoringEnabled,
+} from './scoring.js';
 import { computeIndustryAverage } from '../utils/computeIndustryAverage.js';
 import Vendor from '../models/Vendor.js';
 
@@ -211,8 +220,11 @@ function deriveGaps(checks, blogDetection) {
  * Map detector output (10 checks + blog) onto the legacy 6-bucket scoreBreakdown.
  * Returns null for buckets the detector cannot measure (directoryPresence, reviewSignals).
  * competitivePosition is derived from live platformResults.
+ *
+ * Exported so aeoReportGenerator.js (the LLM rescan path) can populate the
+ * same backwards-compat sub-scores that the PDF renderer still consumes.
  */
-function mapScoreBreakdown(detectorResult, platformResults) {
+export function mapScoreBreakdown(detectorResult, platformResults) {
   const byKey = Object.create(null);
   for (const c of detectorResult.checks || []) byKey[c.key] = c;
 
@@ -445,6 +457,14 @@ export async function buildPublicReport({
     runAt: new Date(),
   };
 
+  // jsonLdPayloads stays off detectorResult — it's feed-through for scoring,
+  // not a persisted sub-doc. The detectorResultSchema in models/AeoReport.js
+  // would silently drop it, but keeping the persisted shape lean is cleaner.
+  const detectorForScoring = {
+    ...detectorResult,
+    jsonLdPayloads: detectorRaw.jsonLdPayloads || [],
+  };
+
   const categoryLabel = customIndustry || CATEGORY_LABELS[category] || category;
 
   const platformResults = await queryAllPlatforms({
@@ -478,6 +498,17 @@ export async function buildPublicReport({
     count: reviews.count ?? null,
   };
 
+  // Places listing category alignment. Reuses the GBP lookup cache —
+  // zero extra Places API calls. 'skipped' for vendor types with no
+  // Places category mapping (equipment / other) — scoring.js
+  // redistributes the 10 points.
+  const vendorTypeForPlaces = getVendorType(category);
+  const placesListing = await checkPlacesListingQuality(
+    companyName,
+    city,
+    vendorTypeForPlaces,
+  );
+
   const summary = buildSummary({
     companyName,
     category,
@@ -490,6 +521,14 @@ export async function buildPublicReport({
   searchedCompany.summary = summary;
 
   const scoreBreakdown = mapScoreBreakdown(detectorResult, platformResults);
+
+  // Dual scoring. Flag default TRUE — DUAL_SCORING=false in Render env reverts
+  // to legacy single-score shape for rollback without a redeploy.
+  const dualEnabled = isDualScoringEnabled();
+  const techResult = dualEnabled ? computeTechnicalHealth(detectorForScoring) : null;
+  const aiResult = dualEnabled
+    ? computeAiVisibility(detectorForScoring, gbp, reviews, placesListing, platformResults)
+    : null;
 
   const aiMentioned =
     Array.isArray(platformResults) && platformResults.some((p) => p.mentioned === true);
@@ -517,6 +556,14 @@ export async function buildPublicReport({
     description: c.description,
   }));
 
+  // When dual scoring is enabled, the legacy `score` field mirrors
+  // aiVisibilityScore so existing frontend surfaces keep rendering a
+  // single number until they migrate. When disabled, fall back to the
+  // detector's /100 sum — same as the pre-dual-scoring public path.
+  const legacyScore = dualEnabled && aiResult?.score != null
+    ? aiResult.score
+    : detectorResult.overallScore;
+
   const result = {
     companyName,
     category,
@@ -526,7 +573,7 @@ export async function buildPublicReport({
     name: name || undefined,
     source: source || undefined,
     reportType: 'full',
-    score: detectorResult.overallScore,
+    score: legacyScore,
     scoreBreakdown,
     searchedCompany,
     competitors,
@@ -541,6 +588,16 @@ export async function buildPublicReport({
     detectorResult,
     tier: 'free',
   };
+
+  if (dualEnabled) {
+    result.technicalHealthScore = techResult?.score ?? null;
+    result.technicalHealthBand = techResult?.band ?? null;
+    result.technicalHealthBreakdown = techResult?.breakdown ?? null;
+    result.aiVisibilityScore = aiResult?.score ?? null;
+    result.aiVisibilityBand = aiResult?.band ?? null;
+    result.aiVisibilityBreakdown = aiResult?.breakdown ?? null;
+  }
+
   result.gapsIdentified = computeGapsIdentified(result);
   return result;
 }

--- a/services/scoring.js
+++ b/services/scoring.js
@@ -122,10 +122,13 @@ function hasFaqPageSchema(detector) {
 // Any @type that indicates a LocalBusiness or Organization entity. The spec
 // has ~50 LocalBusiness subtypes (LegalService, AccountingService,
 // RealEstateAgent, FinancialService, …) — match by substring so we accept
-// any of them without hardcoding every one.
+// any of them without hardcoding every one. 'lawyer' and 'attorney' cover
+// schema.org entries that solicitor sites publish under those exact types.
 const LB_TYPE_SUBSTRINGS = [
   'organization',
   'localbusiness',
+  'lawyer',
+  'attorney',
   'legalservice',
   'accountingservice',
   'realestateagent',
@@ -147,6 +150,13 @@ function isLocalBusinessLike(typeField) {
 
 const LB_REQUIRED_FIELDS = ['name', 'url', 'address', 'telephone', 'image'];
 
+/**
+ * Discrete-band richness grading. The best LB-like payload on the page wins.
+ *   5 of 5 fields → 1.0
+ *   3-4 of 5     → 0.7
+ *   1-2 of 5     → 0.3
+ *   0 of 5 (or no LB-like payload) → 0
+ */
 function gradeLocalBusinessRichness(detector) {
   const payloads = Array.isArray(detector?.jsonLdPayloads) ? detector.jsonLdPayloads : [];
   let best = 0;
@@ -157,26 +167,31 @@ function gradeLocalBusinessRichness(detector) {
       const v = p?.[field];
       if (v !== undefined && v !== null && v !== '') have += 1;
     }
-    const ratio = have / LB_REQUIRED_FIELDS.length;
-    if (ratio > best) best = ratio;
+    let band;
+    if (have >= 5) band = 1.0;
+    else if (have >= 3) band = 0.7;
+    else if (have >= 1) band = 0.3;
+    else band = 0;
+    if (band > best) best = band;
   }
   return best;
 }
 
 /**
- * Banded grading of Google Reviews (count × average rating).
- * Returns 0.0–1.0, scaled against AI_WEIGHTS.reviews by the caller.
+ * Banded grading of Google Reviews (count × average rating). Returns 0.0–1.0,
+ * scaled against AI_WEIGHTS.reviews by the caller.
+ *
+ * Tuned for realistic UK professional-services volumes — a solicitor firm
+ * with 12 reviews at 4.7★ is doing well and should score accordingly.
  */
 function gradeReviews(reviews) {
   if (!reviews || reviews.state !== 'pass') return 0;
   const count = typeof reviews.count === 'number' ? reviews.count : 0;
   const rating = typeof reviews.rating === 'number' ? reviews.rating : 0;
-  if (count >= 50 && rating >= 4.5) return 1.0;
-  if (count >= 25 && rating >= 4.5) return 0.85;
-  if (count >= 25 && rating >= 4.0) return 0.7;
-  if (count >= 10 && rating >= 4.0) return 0.55;
-  if (count >= 5 && rating >= 3.5) return 0.35;
-  if (count >= 3 && rating >= 3.0) return 0.2;
+  if (count >= 20 && rating >= 4.5) return 1.0;
+  if (count >= 10 && rating >= 4.3) return 0.85;
+  if (count >= 5 && rating >= 4.0) return 0.65;
+  if (count >= 3 && rating >= 3.5) return 0.4;
   return 0;
 }
 

--- a/services/scoring.js
+++ b/services/scoring.js
@@ -1,0 +1,270 @@
+/**
+ * Dual scoring for AEO reports.
+ *
+ * Two deterministic 0-100 scores computed from signals the detector + GBP/
+ * Places + platform queries already gather:
+ *
+ *   - Technical Health (8 signals) tracks SEMrush/Searchable-style basics
+ *   - AI Visibility (7 signals) covers AI-era signals
+ *
+ * No LLM calls. Every bucket comes from a deterministic check or API
+ * response. Replaces the fabricated scoring prose in aeoReportGenerator.js.
+ *
+ * Feature flag: DUAL_SCORING (default TRUE). Flip to 'false' in Render env
+ * to revert responses to legacy single-score fields — see
+ * isDualScoringEnabled(). The flag is a rollback lever, not a rollout
+ * stage — new reports should ship with dual scoring live by default.
+ */
+
+/**
+ * DUAL_SCORING flag reader. Undefined, null, empty, or any non-'false' value
+ * resolves to enabled. Only a literal 'false' (case-insensitive, trimmed)
+ * disables it.
+ */
+export function isDualScoringEnabled() {
+  const raw = process.env.DUAL_SCORING;
+  if (raw === undefined || raw === null) return true;
+  return String(raw).trim().toLowerCase() !== 'false';
+}
+
+const TECH_WEIGHTS = Object.freeze({
+  ssl: 15,
+  viewport: 10,
+  meta: 17,
+  h1: 10,
+  schema: 13,
+  social: 10,
+  contact: 11,
+  content: 14,
+});
+
+const AI_WEIGHTS = Object.freeze({
+  faqSchema: 15,
+  localBusiness: 15,
+  blog: 10,
+  gbp: 15,
+  reviews: 15,
+  placesListing: 10,
+  aiMentions: 20,
+});
+
+export function bandForTechnicalHealth(score) {
+  if (typeof score !== 'number' || Number.isNaN(score)) return null;
+  if (score >= 85) return 'Excellent';
+  if (score >= 70) return 'Good';
+  if (score >= 50) return 'Needs Work';
+  return 'Critical';
+}
+
+export function bandForAiVisibility(score) {
+  if (typeof score !== 'number' || Number.isNaN(score)) return null;
+  if (score >= 70) return 'Strong';
+  if (score >= 50) return 'Moderate';
+  if (score >= 30) return 'Early Stage';
+  return 'Starting Out';
+}
+
+function checkByKey(detector, key) {
+  if (!detector || !Array.isArray(detector.checks)) return null;
+  return detector.checks.find((c) => c.key === key) || null;
+}
+
+function scaleCheck(detector, key, weight) {
+  const c = checkByKey(detector, key);
+  if (!c || typeof c.score !== 'number') return 0;
+  const max = typeof c.maxScore === 'number' && c.maxScore > 0 ? c.maxScore : 10;
+  const raw = Math.max(0, Math.min(max, c.score));
+  return Math.round((raw / max) * weight);
+}
+
+/**
+ * Compute Technical Health from detector output. Drops the "speed" signal
+ * (HTML byte size penalises SSR frameworks unfairly); redistributes its
+ * weight per TECH_WEIGHTS (summing to 100).
+ */
+export function computeTechnicalHealth(detector) {
+  if (!detector || !Array.isArray(detector.checks)) {
+    return { score: null, band: null, breakdown: null };
+  }
+
+  const breakdown = {
+    ssl: scaleCheck(detector, 'ssl', TECH_WEIGHTS.ssl),
+    viewport: scaleCheck(detector, 'viewport', TECH_WEIGHTS.viewport),
+    meta: scaleCheck(detector, 'meta', TECH_WEIGHTS.meta),
+    h1: scaleCheck(detector, 'h1', TECH_WEIGHTS.h1),
+    schema: scaleCheck(detector, 'schema', TECH_WEIGHTS.schema),
+    social: scaleCheck(detector, 'social', TECH_WEIGHTS.social),
+    contact: scaleCheck(detector, 'contact', TECH_WEIGHTS.contact),
+    content: scaleCheck(detector, 'content', TECH_WEIGHTS.content),
+  };
+
+  const score = Math.max(
+    0,
+    Math.min(100, Object.values(breakdown).reduce((a, b) => a + b, 0)),
+  );
+  return { score, band: bandForTechnicalHealth(score), breakdown };
+}
+
+function typeIs(typeField, wanted) {
+  const w = wanted.toLowerCase();
+  if (typeof typeField === 'string') return typeField.toLowerCase() === w;
+  if (Array.isArray(typeField)) {
+    return typeField.some((t) => typeof t === 'string' && t.toLowerCase() === w);
+  }
+  return false;
+}
+
+function hasFaqPageSchema(detector) {
+  const payloads = Array.isArray(detector?.jsonLdPayloads) ? detector.jsonLdPayloads : [];
+  return payloads.some((p) => typeIs(p?.['@type'], 'FAQPage'));
+}
+
+// Any @type that indicates a LocalBusiness or Organization entity. The spec
+// has ~50 LocalBusiness subtypes (LegalService, AccountingService,
+// RealEstateAgent, FinancialService, …) — match by substring so we accept
+// any of them without hardcoding every one.
+const LB_TYPE_SUBSTRINGS = [
+  'organization',
+  'localbusiness',
+  'legalservice',
+  'accountingservice',
+  'realestateagent',
+  'financialservice',
+  'professionalservice',
+];
+
+function isLocalBusinessLike(typeField) {
+  const fields = typeof typeField === 'string' ? [typeField]
+    : Array.isArray(typeField) ? typeField
+    : [];
+  for (const t of fields) {
+    if (typeof t !== 'string') continue;
+    const low = t.toLowerCase();
+    if (LB_TYPE_SUBSTRINGS.some((s) => low.includes(s))) return true;
+  }
+  return false;
+}
+
+const LB_REQUIRED_FIELDS = ['name', 'url', 'address', 'telephone', 'image'];
+
+function gradeLocalBusinessRichness(detector) {
+  const payloads = Array.isArray(detector?.jsonLdPayloads) ? detector.jsonLdPayloads : [];
+  let best = 0;
+  for (const p of payloads) {
+    if (!isLocalBusinessLike(p?.['@type'])) continue;
+    let have = 0;
+    for (const field of LB_REQUIRED_FIELDS) {
+      const v = p?.[field];
+      if (v !== undefined && v !== null && v !== '') have += 1;
+    }
+    const ratio = have / LB_REQUIRED_FIELDS.length;
+    if (ratio > best) best = ratio;
+  }
+  return best;
+}
+
+/**
+ * Banded grading of Google Reviews (count × average rating).
+ * Returns 0.0–1.0, scaled against AI_WEIGHTS.reviews by the caller.
+ */
+function gradeReviews(reviews) {
+  if (!reviews || reviews.state !== 'pass') return 0;
+  const count = typeof reviews.count === 'number' ? reviews.count : 0;
+  const rating = typeof reviews.rating === 'number' ? reviews.rating : 0;
+  if (count >= 50 && rating >= 4.5) return 1.0;
+  if (count >= 25 && rating >= 4.5) return 0.85;
+  if (count >= 25 && rating >= 4.0) return 0.7;
+  if (count >= 10 && rating >= 4.0) return 0.55;
+  if (count >= 5 && rating >= 3.5) return 0.35;
+  if (count >= 3 && rating >= 3.0) return 0.2;
+  return 0;
+}
+
+function gradeGbp(gbp) {
+  if (!gbp) return 0;
+  if (gbp.state === 'pass') return 1.0;
+  if (gbp.state === 'amber') return 10 / 15;
+  return 0;
+}
+
+function gradePlacesListing(listing) {
+  if (!listing) return 0;
+  if (listing.state === 'pass') return 1.0;
+  if (listing.state === 'amber') return 0.6;
+  return 0;
+}
+
+function gradeAiMentions(platformResults) {
+  if (!Array.isArray(platformResults) || platformResults.length === 0) return 0;
+  const valid = platformResults.filter(
+    (p) => p && !p.error && p.mentioned !== null && p.mentioned !== undefined,
+  );
+  if (valid.length === 0) return 0;
+  const hits = valid.filter((p) => p.mentioned === true).length;
+  return hits / valid.length;
+}
+
+/**
+ * Compute AI Visibility from detector + GBP + reviews + Places listing +
+ * platform mention results.
+ *
+ * When the vendor type has no Places category mapping, `placesListing.state`
+ * is 'skipped' — its 10 points are redistributed proportionally across the
+ * other six signals so the 0-100 ceiling is preserved.
+ */
+export function computeAiVisibility(detector, gbp, reviews, placesListing, platformResults) {
+  if (!detector || !Array.isArray(detector.checks)) {
+    return { score: null, band: null, breakdown: null };
+  }
+
+  const faqFrac = hasFaqPageSchema(detector) ? 1 : 0;
+  const lbFrac = gradeLocalBusinessRichness(detector);
+  const blogFrac = detector?.blogDetection?.hasBlog ? 1 : 0;
+  const gbpFrac = gradeGbp(gbp);
+  const reviewFrac = gradeReviews(reviews);
+  const aiFrac = gradeAiMentions(platformResults);
+
+  const placesSkipped = placesListing?.state === 'skipped';
+  const placesFrac = placesSkipped ? 0 : gradePlacesListing(placesListing);
+
+  const weights = { ...AI_WEIGHTS };
+  if (placesSkipped) {
+    const extra = weights.placesListing;
+    const keys = Object.keys(weights).filter((k) => k !== 'placesListing');
+    const totalOther = keys.reduce((a, k) => a + weights[k], 0);
+    for (const k of keys) {
+      weights[k] = weights[k] + (weights[k] / totalOther) * extra;
+    }
+    weights.placesListing = 0;
+  }
+
+  const breakdown = {
+    faqSchema: Math.round(faqFrac * weights.faqSchema),
+    localBusiness: Math.round(lbFrac * weights.localBusiness),
+    blog: Math.round(blogFrac * weights.blog),
+    gbp: Math.round(gbpFrac * weights.gbp),
+    reviews: Math.round(reviewFrac * weights.reviews),
+    placesListing: Math.round(placesFrac * weights.placesListing),
+    aiMentions: Math.round(aiFrac * weights.aiMentions),
+  };
+
+  const score = Math.max(
+    0,
+    Math.min(100, Object.values(breakdown).reduce((a, b) => a + b, 0)),
+  );
+
+  return {
+    score,
+    band: bandForAiVisibility(score),
+    breakdown,
+    placesSkipped,
+  };
+}
+
+export default {
+  isDualScoringEnabled,
+  computeTechnicalHealth,
+  computeAiVisibility,
+  bandForTechnicalHealth,
+  bandForAiVisibility,
+};


### PR DESCRIPTION
## Summary

Replaces the fabricated single 0-100 score in the AEO reports with two
deterministic 0-100 scores computed from signals the detector + Places
API + platform queries already gather:

- **Technical Health** (8 signals, weights sum to 100) — HTTPS, mobile
  viewport, meta title/desc, single H1, schema count, social links,
  contact info, content depth. Tracks SEMrush / Searchable basics. The
  old "Page Weight" signal is dropped — HTML byte size penalises SSR.
- **AI Visibility** (7 signals, weights sum to 100) — FAQPage schema
  (strict, not plain FAQ section), LocalBusiness/Organization schema
  richness, blog detection, GBP state, reviews (count × rating band),
  Places listing category alignment (new), AI platform mentions.

The LLM in `services/aeoReportGenerator.js` no longer produces
`score`, `scoreBreakdown`, or `gaps`. It is retained only for
`searchedCompany.summary` and `competitors`. Scoring is now
deterministic end to end.

External tool comparison this is calibrated against: tendorai.com
currently shows at SEMrush 93% / Searchable 87.8 while the free AEO
report shows 32-38/100 — the gap destroys trust with any prospect
who has used either tool. The new scores track the same signals
those tools weight.

## Files changed

### New
- `services/scoring.js` — `computeTechnicalHealth`,
  `computeAiVisibility`, bands, and the `DUAL_SCORING` flag reader.

### Modified (primitives)
- `services/googleBusinessProfile.js` — `places.types` added to
  `FIELD_MASK`; new exported `checkPlacesListingQuality(companyName,
  city, expectedVendorType)` reusing the shared 24h `lookupPlace`
  cache (zero extra Places API calls). Category mapping per plan
  (`solicitor` → `['lawyer','legal_services']`, `accountant` →
  `['accounting']`, `mortgage-advisor` →
  `['finance','insurance_agency']`, `estate-agent` →
  `['real_estate_agency']`). Unmapped vendor types return
  `state: 'skipped'` so the 10 points redistribute.
- `services/aeoDetector.js` — `runDetector` / `analyseAeoSignals`
  expose `jsonLdPayloads` (parsed, `@graph`-flattened) so scoring
  can grade LocalBusiness / Organization richness without
  re-fetching the page.
- `models/AeoReport.js` — six new dual-score fields alongside legacy
  `score` / `scoreBreakdown`. Legacy `score` mirrors
  `aiVisibilityScore` for back-compat; historical reports keep
  their original values.

### Modified (integration)
- `services/publicAeoReportBuilder.js` — wires dual scoring for the
  free `/api/public/aeo-report` flow; exports `mapScoreBreakdown`
  so the LLM path shares the 6-bucket back-compat shape.
- `services/aeoReportGenerator.js` — stripped: `getScoringHints`,
  `getGapHints`, score / scoreBreakdown / gaps prose from the
  prompt, the "Most small businesses score 15-45" bias phrase,
  score parsing + `clamp`. Added: parallel detector +
  `platformQuery` + LLM; GBP / reviews / Places listing overrides;
  dual scoring; detector-derived gaps. New optional `websiteUrl`
  param drives the detector. Comment near the checklist prompt
  documents why `hasBrands` stays LLM-only.
- `routes/vendorUploadRoutes.js` — Pro vendor rescan plumbs
  `vendor.contactInfo.website` and exposes dual-score fields.
- `jobs/scheduledReports.js` — Pro weekly / Starter monthly jobs
  plumb `vendor.contactInfo.website`.
- `routes/adminRoutes.js` — `generate-vendor-report` and
  `generate-vendor-reports-batch` accept optional `websiteUrl` and
  return dual-score fields.
- `scripts/generateBatchReports.js` — selects `contactInfo` and
  passes `vendor.contactInfo.website` through to
  `generateFullReport`. Log line surfaces both scores plus legacy.
- `scripts/testReportGeneration.js` — adds a `websiteUrl` field on
  each test entry (default null with comment) and pipes it through.
  Result summary surfaces Technical Health, AI Visibility, and
  bands.

## Feature flag — `DUAL_SCORING`

Default **TRUE**. The flag is a rollback lever, not a rollout stage.

- `DUAL_SCORING` unset / any non-`false` value → dual scoring active.
  All six new fields populated on responses and on the DB doc; legacy
  `score` mirrors `aiVisibilityScore`.
- `DUAL_SCORING=false` in Render env → responses return only legacy
  fields. Rollback in seconds, no redeploy.

## Rollback

If dual scoring ships a bug, set `DUAL_SCORING=false` in Render env
and restart the service. Reports created while the flag was on keep
their dual-score fields in the DB; responses simply omit them until
the flag is flipped back.

## Frontend TODO (tendorai-nextjs, separate session)

Backend changes are complete; rendering the two scores is
intentionally out of scope for this PR.

- [ ] Render `technicalHealthScore` and `aiVisibilityScore` side by
      side with their bands (`technicalHealthBand` /
      `aiVisibilityBand`).
- [ ] Technical Health bands: 85+ Excellent, 70-84 Good, 50-69 Needs
      Work, <50 Critical. AI Visibility bands: 70+ Strong, 50-69
      Moderate, 30-49 Early Stage, <30 Starting Out.
- [ ] Relabel the old "Directory Presence" bucket to "Google Maps
      Presence" where the dual-score breakdown is surfaced.
- [ ] Render `technicalHealthBreakdown` and `aiVisibilityBreakdown`
      (objects of signal → points) when showing a detailed view.
- [ ] Handle legacy reports: when both new score fields are `null`,
      show a one-time banner explaining the report predates dual
      scoring. Do not try to back-fill.
- [ ] Remove any UI text that references the old single 0-100 score
      being authoritative — the headline number is now AI Visibility
      (which the legacy `score` mirrors), with Technical Health
      second.
- [ ] Update any PDF preview / CTA copy that still says "Your
      Score: X/100" to reflect two scores.

### Server-side PDF renderer (paired with frontend work)

`services/aeoReportPdf.js` is intentionally **out of scope** for
this PR. It still renders the legacy 6-bucket `scoreBreakdown` (the
LLM path keeps `scoreBreakdown` populated via the shared
`mapScoreBreakdown` helper, so the PDF does not break). Updating
the PDF to render Technical Health + AI Visibility — headline
numbers, bands, and the new breakdown objects — should be
sequenced with the tendorai-nextjs HTML work so the two surfaces
stay visually consistent.

## Constraints honoured

- CLAUDE.md: feature branch, PR against `main`, not merged by
  Claude. Per the 400+ line rule, `aeoReportGenerator.js`
  (~900 lines) refactor is split into two commits on this branch.
- GBP fix from PR #30 is not touched: `stripCompanySuffix` and the
  shared `lookupPlace` are unchanged. `hasGoogleBusiness=true`,
  `state=pass` for tendorai.com should still hold.
- Google Places API key is read from `process.env.GOOGLE_PLACES_API_KEY`
  inside `googleBusinessProfile.js`; no logging of the key, no
  exposure to clients.

## Review feedback applied (commit `d2dd661`)

1. **PDF renderer**: confirmed out of scope; PR description now
   pairs it explicitly with the frontend session (see above).
2. **LocalBusiness richness**: `lawyer` and `attorney` added to the
   accepted `@type` substring list (covers schema.org entries
   solicitor sites publish under those exact types). Required-field
   grading switched from a linear ratio to discrete bands per
   approval:
   - 5 of 5 → 1.0
   - 3-4 of 5 → 0.7
   - 1-2 of 5 → 0.3
   - 0 of 5 → 0
3. **Reviews thresholds**: softened to the requested bands so a
   solicitor firm with 12 reviews at 4.7★ scores well:
   - 20+ @ 4.5★+ → 1.0
   - 10+ @ 4.3★+ → 0.85
   - 5+ @ 4.0★+ → 0.65
   - 3+ @ 3.5★+ → 0.4
   - <3 reviews → 0
4. **Scripts migrated**: `scripts/generateBatchReports.js` now
   selects `contactInfo` and pipes `vendor.contactInfo.website`
   into `generateFullReport`. `scripts/testReportGeneration.js`
   has a `websiteUrl` field on each test entry (default null with a
   comment — operators populate real URLs to exercise dual scoring
   end to end). Both scripts surface the new scores in their logs.
5. **`hasBrands` LLM-only**: comment added at
   `services/aeoReportGenerator.js` above `getChecklistPrompt`
   explaining why — accreditation badges and footer text aren't
   reliably scrapeable, LLM with web search makes a better call
   than a regex would.

https://claude.ai/code/session_014Py5CZntg9xVMevGm6z5oS