### PR TITLE
fix(aeo): recognise firm mentions across name variants + stop listing firm as its own competitor

### DIFF
--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -781,6 +781,7 @@ export async function generateFullReport({
     category,
     city,
     categoryLabel,
+    websiteUrl,
   }).catch((err) => {
     console.error('[AEO] Platform queries failed:', err.message);
     return [];

--- a/services/platformQuery/chatgpt.js
+++ b/services/platformQuery/chatgpt.js
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryChatGPT({ companyName, categoryLabel, city }) {
+export async function queryChatGPT({ companyName, categoryLabel, city, websiteUrl }) {
   const client = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
@@ -15,7 +15,7 @@ export async function queryChatGPT({ companyName, categoryLabel, city }) {
   });
 
   const rawResponse = response.choices?.[0]?.message?.content || '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'chatgpt',

--- a/services/platformQuery/claude.js
+++ b/services/platformQuery/claude.js
@@ -1,7 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryClaude({ companyName, categoryLabel, city }) {
+export async function queryClaude({ companyName, categoryLabel, city, websiteUrl }) {
   const client = new Anthropic({
     apiKey: process.env.ANTHROPIC_API_KEY,
   });
@@ -17,7 +17,7 @@ export async function queryClaude({ companyName, categoryLabel, city }) {
   const rawResponse = response.content?.[0]?.type === 'text'
     ? response.content[0].text
     : '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'claude',

--- a/services/platformQuery/gemini.js
+++ b/services/platformQuery/gemini.js
@@ -1,7 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryGemini({ companyName, categoryLabel, city }) {
+export async function queryGemini({ companyName, categoryLabel, city, websiteUrl }) {
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
   const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
 
@@ -9,7 +9,7 @@ export async function queryGemini({ companyName, categoryLabel, city }) {
 
   const result = await model.generateContent(prompt);
   const rawResponse = result.response?.text() || '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'gemini',

--- a/services/platformQuery/grok.js
+++ b/services/platformQuery/grok.js
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryGrok({ companyName, categoryLabel, city }) {
+export async function queryGrok({ companyName, categoryLabel, city, websiteUrl }) {
   const client = new OpenAI({
     apiKey: process.env.GROK_API_KEY,
     baseURL: 'https://api.x.ai/v1',
@@ -16,7 +16,7 @@ export async function queryGrok({ companyName, categoryLabel, city }) {
   });
 
   const rawResponse = response.choices?.[0]?.message?.content || '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'grok',

--- a/services/platformQuery/index.js
+++ b/services/platformQuery/index.js
@@ -36,17 +36,17 @@ async function queryWithTimeout(platform, params) {
 /**
  * Query a single platform by key.
  * @param {string} platformKey - e.g. 'chatgpt', 'perplexity'
- * @param {Object} params - { companyName, categoryLabel, city }
+ * @param {Object} params - { companyName, categoryLabel, city, websiteUrl? }
  * @returns {Promise<Object>} Platform result object with status field
  */
-export async function querySinglePlatform(platformKey, { companyName, categoryLabel, city }) {
+export async function querySinglePlatform(platformKey, { companyName, categoryLabel, city, websiteUrl }) {
   const platform = PLATFORMS.find(p => p.key === platformKey && process.env[p.envKey]);
   if (!platform) {
     throw new Error(`Platform "${platformKey}" not found or not configured`);
   }
 
   try {
-    const result = await queryWithTimeout(platform, { companyName, categoryLabel, city });
+    const result = await queryWithTimeout(platform, { companyName, categoryLabel, city, websiteUrl });
     return { ...result, status: 'checked' };
   } catch (err) {
     return {
@@ -65,10 +65,12 @@ export async function querySinglePlatform(platformKey, { companyName, categoryLa
 
 /**
  * Query all enabled AI platforms in parallel.
- * @param {Object} params - { companyName, category, city, categoryLabel }
+ * @param {Object} params - { companyName, category, city, categoryLabel, websiteUrl? }
+ *   websiteUrl is threaded through to the response parser so URL citations
+ *   (Perplexity-style) count as mentions even when the firm name is absent.
  * @returns {Promise<Array>} Array of platform result objects
  */
-export async function queryAllPlatforms({ companyName, category, city, categoryLabel }) {
+export async function queryAllPlatforms({ companyName, category, city, categoryLabel, websiteUrl }) {
   const enabledPlatforms = PLATFORMS.filter(p => process.env[p.envKey]);
 
   if (enabledPlatforms.length === 0) {
@@ -80,7 +82,7 @@ export async function queryAllPlatforms({ companyName, category, city, categoryL
 
   const results = await Promise.allSettled(
     enabledPlatforms.map(platform =>
-      queryWithTimeout(platform, { companyName, categoryLabel, city })
+      queryWithTimeout(platform, { companyName, categoryLabel, city, websiteUrl })
         .then(result => ({
           ...result,
           status: 'checked',

--- a/services/platformQuery/meta.js
+++ b/services/platformQuery/meta.js
@@ -1,7 +1,7 @@
 import Groq from 'groq-sdk';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryMeta({ companyName, categoryLabel, city }) {
+export async function queryMeta({ companyName, categoryLabel, city, websiteUrl }) {
   const client = new Groq({
     apiKey: process.env.GROQ_API_KEY,
   });
@@ -15,7 +15,7 @@ export async function queryMeta({ companyName, categoryLabel, city }) {
   });
 
   const rawResponse = response.choices?.[0]?.message?.content || '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'meta',

--- a/services/platformQuery/nameMatch.js
+++ b/services/platformQuery/nameMatch.js
@@ -1,0 +1,155 @@
+/**
+ * Company-name matching helpers shared by platform response parsing and
+ * competitor aggregation. The real detector's Places lookup (PR #30) already
+ * normalizes company names to handle suffix and unicode variation; this module
+ * extends the same approach to AI-platform output so that:
+ *
+ *   1. A firm is detected as "mentioned" even when the AI writes their name
+ *      with a different suffix ("Celtic Frozen Drinks Ltd" vs "Celtic Frozen
+ *      Drinks"), different case, stray punctuation, or diacritics.
+ *   2. The firm is excluded from its own competitor list via the same
+ *      normalized comparison.
+ *   3. If the AI only cites the firm's URL (common with Perplexity), a
+ *      domain-token match still counts as a mention.
+ */
+
+// Trailing UK / international company-form suffixes. Matched at end of name
+// only — "Sons of Anarchy" stays intact but "Smith & Sons Ltd" → "Smith".
+// Kept in sync with googleBusinessProfile.js, with a few extras added for AI
+// output variation (Group, Holdings, Services, Corp, etc.).
+const COMPANY_SUFFIX_RE = /[\s,.]+(?:ltd|limited|llp|plc|pvt|co|company|uk|inc|incorporated|corp|corporation|group|holdings|services|solutions|gmbh|bv|sa|srl|(?:&\s*|and\s+)co|(?:&\s*|and\s+)sons)\.?$/i;
+
+function stripDiacritics(s) {
+  return String(s || '').normalize('NFD').replace(/\p{M}/gu, '');
+}
+
+/**
+ * Normalize a company name for comparison: lowercase, strip diacritics, strip
+ * punctuation, collapse whitespace, iteratively strip trailing company-form
+ * suffixes. Empty input returns ''. Input that is entirely a suffix (unlikely
+ * but possible) falls back to the lowercased original so we never produce a
+ * zero-length token that matches every string.
+ */
+export function normalizeCompanyName(name) {
+  if (!name) return '';
+  const raw = String(name);
+  let s = stripDiacritics(raw)
+    .toLowerCase()
+    .replace(/[''`´]/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(COMPANY_SUFFIX_RE, '').trim();
+  } while (s !== prev && s.length > 0);
+  s = s.replace(/[.,;:()'"\[\]{}!?]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (s) return s;
+  return raw.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function normalizeText(text) {
+  return stripDiacritics(text)
+    .toLowerCase()
+    .replace(/[.,;:()'"\[\]{}!?]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract hostname-shaped tokens from a URL so we can match a firm when the
+ * AI cites their website instead of naming them. Returns at most two tokens:
+ * the full bare hostname and the label-without-TLD, both lowercased. Tokens
+ * of length < 5 are dropped to avoid false positives from very short domains
+ * (".co.uk" etc. are stripped anyway, but common words like "abc" are not
+ * specific enough to key a mention on).
+ */
+export function extractDomainTokens(url) {
+  if (!url) return [];
+  const raw = String(url).trim();
+  if (!raw) return [];
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`;
+  let host;
+  try {
+    host = new URL(withScheme).hostname;
+  } catch {
+    host = raw.replace(/^https?:\/\//i, '').split(/[\/?#]/)[0];
+  }
+  host = host.replace(/^www\./i, '').toLowerCase();
+  const labels = host.split('.').filter(Boolean);
+  if (labels.length === 0) return [];
+  const tokens = new Set();
+  if (host.length >= 5) tokens.add(host);
+  if (labels.length >= 2) {
+    const withoutTld = labels.slice(0, -1).join('.');
+    if (withoutTld.length >= 5) tokens.add(withoutTld);
+    const first = labels[0];
+    if (first.length >= 5) tokens.add(first);
+  }
+  return [...tokens];
+}
+
+/**
+ * True if `text` mentions `companyName`, using normalized substring matching
+ * plus an optional URL-citation fallback. Does NOT check for negation context
+ * — callers that care about "I could not find X" style false positives still
+ * need to run their own sentiment check on the snippet (see
+ * isPositiveMention in prompt.js).
+ */
+export function isCompanyMentioned(text, companyName, websiteUrl = null) {
+  if (!text || !companyName) return false;
+  const textNorm = normalizeText(text);
+  if (!textNorm) return false;
+
+  const companyNorm = normalizeCompanyName(companyName);
+  if (companyNorm && textNorm.includes(companyNorm)) return true;
+
+  // Safety net: a firm whose entire name normalizes to nothing (pathological,
+  // e.g. pure punctuation) would otherwise match every string above.
+  // normalizeCompanyName guards against empty output, but we still check the
+  // raw lowercased form in case the suffix strip ate something meaningful.
+  const rawLower = String(companyName).toLowerCase().trim();
+  if (rawLower && rawLower !== companyNorm && textNorm.includes(normalizeText(rawLower))) {
+    return true;
+  }
+
+  for (const token of extractDomainTokens(websiteUrl)) {
+    if (textNorm.includes(token)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * True if `candidateName` refers to the same firm as `companyName`. Used to
+ * filter the firm out of their own competitor list. Normalized equality plus
+ * substring-either-direction handles the common cases:
+ *   - "Celtic Frozen Drinks" vs "Celtic Frozen Drinks Ltd"  → same
+ *   - "Nutrivend" vs "Nutrivend Group Limited"              → same
+ *   - "Smith Solicitors" vs "Smith & Jones Solicitors"      → NOT same
+ */
+export function isSameFirm(candidateName, companyName) {
+  if (!candidateName || !companyName) return false;
+  const a = normalizeCompanyName(candidateName);
+  const b = normalizeCompanyName(companyName);
+  if (!a || !b) return false;
+  if (a === b) return true;
+  // Substring either direction — handles suffix-only differences without
+  // matching arbitrary word overlaps (we do not split on whitespace).
+  if (a.includes(b) || b.includes(a)) return true;
+  return false;
+}
+
+/**
+ * True if a candidate website belongs to the same domain as the searched
+ * firm's website. Both inputs may be bare hostnames or full URLs. Only the
+ * registrable portion is compared so "celticfrozendrinks.co.uk" matches
+ * "www.celticfrozendrinks.co.uk/about".
+ */
+export function isSameDomain(candidateUrl, firmUrl) {
+  const a = extractDomainTokens(candidateUrl);
+  const b = extractDomainTokens(firmUrl);
+  if (a.length === 0 || b.length === 0) return false;
+  const aSet = new Set(a);
+  return b.some((token) => aSet.has(token));
+}

--- a/services/platformQuery/perplexity.js
+++ b/services/platformQuery/perplexity.js
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { buildPrompt, parsePlatformResponse } from './prompt.js';
 
-export async function queryPerplexity({ companyName, categoryLabel, city }) {
+export async function queryPerplexity({ companyName, categoryLabel, city, websiteUrl }) {
   const client = new OpenAI({
     apiKey: process.env.PERPLEXITY_API_KEY,
     baseURL: 'https://api.perplexity.ai',
@@ -16,7 +16,7 @@ export async function queryPerplexity({ companyName, categoryLabel, city }) {
   });
 
   const rawResponse = response.choices?.[0]?.message?.content || '';
-  const parsed = parsePlatformResponse(rawResponse, companyName);
+  const parsed = parsePlatformResponse(rawResponse, companyName, { websiteUrl });
 
   return {
     platform: 'perplexity',

--- a/services/platformQuery/prompt.js
+++ b/services/platformQuery/prompt.js
@@ -2,6 +2,12 @@
  * Shared prompt builder and response parser for multi-platform AI queries.
  */
 
+import {
+  isCompanyMentioned,
+  isSameFirm,
+  normalizeCompanyName,
+} from './nameMatch.js';
+
 /**
  * Build the prompt sent to each AI platform.
  */
@@ -101,14 +107,29 @@ export function isValidBusinessName(name) {
 /**
  * Check if a mention of the company name is a genuine positive mention,
  * not a negation like "I couldn't find", "not mentioned", etc.
+ *
+ * Locates the mention by finding the normalized company name inside the
+ * normalized text. That way we catch variants like "Celtic Frozen Drinks Ltd"
+ * when the search term is "Celtic Frozen Drinks" (or vice-versa) instead of
+ * bailing out at the strict substring check the way the old implementation
+ * did.
  */
 function isPositiveMention(text, companyName) {
-  const companyLower = companyName.toLowerCase();
   const textLower = text.toLowerCase();
-  const idx = textLower.indexOf(companyLower);
-  if (idx === -1) return false;
+  const companyNorm = normalizeCompanyName(companyName);
+  if (!companyNorm) return false;
 
-  // Check the surrounding context (100 chars before the mention)
+  // Find the mention position in the lower-cased original text so the
+  // "100 chars before" negation window operates on real characters. We try
+  // the normalized name first, then fall back to the raw lowercased name for
+  // cases where normalization stripped something the text kept verbatim.
+  let idx = textLower.indexOf(companyNorm);
+  if (idx === -1) {
+    const rawLower = String(companyName).toLowerCase().trim();
+    if (rawLower) idx = textLower.indexOf(rawLower);
+  }
+  if (idx === -1) return true;
+
   const before = textLower.substring(Math.max(0, idx - 100), idx);
 
   const negationPatterns = [
@@ -134,14 +155,21 @@ function isPositiveMention(text, companyName) {
 
 /**
  * Parse an AI platform's response to extract mention data.
+ *
+ * @param {string} responseText - raw model output
+ * @param {string} companyName  - searched firm name
+ * @param {Object} [opts]
+ * @param {string} [opts.websiteUrl] - searched firm's site, used so a URL
+ *   citation (e.g. Perplexity's inline source links) still registers as a
+ *   mention even if the model omits the name.
  */
-export function parsePlatformResponse(responseText, companyName) {
+export function parsePlatformResponse(responseText, companyName, opts = {}) {
   if (!responseText) {
     return { mentioned: false, position: null, snippet: null, competitors: [] };
   }
 
   const response = responseText;
-  const companyLower = companyName.toLowerCase();
+  const websiteUrl = typeof opts === 'string' ? opts : opts?.websiteUrl || null;
 
   // Handle explicit no-results signal
   if (response.trim() === 'NO_BUSINESSES_FOUND' ||
@@ -166,7 +194,7 @@ export function parsePlatformResponse(responseText, companyName) {
   const lowerResponse = response.toLowerCase();
   const isGenericAdvice = adviceSignals.some(signal => lowerResponse.includes(signal));
 
-  if (isGenericAdvice && !lowerResponse.includes(companyLower)) {
+  if (isGenericAdvice && !isCompanyMentioned(response, companyName, websiteUrl)) {
     return {
       mentioned: false,
       position: null,
@@ -177,9 +205,12 @@ export function parsePlatformResponse(responseText, companyName) {
 
   const text = response;
 
-  // Check if the company is mentioned (case-insensitive, partial match)
-  // Filter out negative/false mentions
-  const rawMentioned = text.toLowerCase().includes(companyLower);
+  // Flexible mention check: normalized substring match against the firm name
+  // (case/suffix/diacritic/punctuation-insensitive) plus a URL-citation
+  // fallback so we count Perplexity-style inline source links as mentions.
+  // Then run the existing negation-context sentiment check to filter out
+  // "I could not find X" style false positives.
+  const rawMentioned = isCompanyMentioned(text, companyName, websiteUrl);
   const mentioned = rawMentioned ? isPositiveMention(text, companyName) : false;
 
   // Try to determine position from explicitly numbered lists only.
@@ -196,8 +227,7 @@ export function parsePlatformResponse(responseText, companyName) {
     for (const pattern of numberedPatterns) {
       let match;
       while ((match = pattern.exec(text)) !== null) {
-        const lineText = match[2].toLowerCase();
-        if (lineText.includes(companyLower)) {
+        if (isCompanyMentioned(match[2], companyName, websiteUrl)) {
           const num = parseInt(match[1], 10);
           // Sanity check: position should be 1-10
           if (num >= 1 && num <= 10) {
@@ -214,8 +244,8 @@ export function parsePlatformResponse(responseText, companyName) {
   let snippet = null;
   if (mentioned) {
     const sentences = text.split(/(?<=[.!?])\s+/);
-    const mentionSentences = sentences.filter(s =>
-      s.toLowerCase().includes(companyLower)
+    const mentionSentences = sentences.filter((s) =>
+      isCompanyMentioned(s, companyName, websiteUrl),
     );
     if (mentionSentences.length > 0) {
       snippet = mentionSentences.slice(0, 2).join(' ').trim();
@@ -236,7 +266,7 @@ export function parsePlatformResponse(responseText, companyName) {
     const reason = (match[2] || '').replace(/\*\*/g, '').trim();
     if (
       name &&
-      !name.toLowerCase().includes(companyLower) &&
+      !isSameFirm(name, companyName) &&
       !competitors.some(c => c.name === name) &&
       isValidBusinessName(name)
     ) {
@@ -252,7 +282,7 @@ export function parsePlatformResponse(responseText, companyName) {
       const name = nameMatch[1].replace(/\*\*/g, '').trim();
       if (
         name &&
-        !name.toLowerCase().includes(companyLower) &&
+        !isSameFirm(name, companyName) &&
         !competitors.some(c => c.name === name) &&
         isValidBusinessName(name)
       ) {
@@ -269,7 +299,7 @@ export function parsePlatformResponse(responseText, companyName) {
       const name = boldMatch[1].trim();
       if (
         name &&
-        !name.toLowerCase().includes(companyLower) &&
+        !isSameFirm(name, companyName) &&
         !competitors.some(c => c.name === name) &&
         isValidBusinessName(name)
       ) {

--- a/services/publicAeoReportBuilder.js
+++ b/services/publicAeoReportBuilder.js
@@ -13,6 +13,7 @@
 import { runDetector } from './aeoDetector.js';
 import { queryAllPlatforms } from './platformQuery/index.js';
 import { isValidBusinessName } from './platformQuery/prompt.js';
+import { isSameFirm, isSameDomain } from './platformQuery/nameMatch.js';
 import {
   checkGoogleBusinessProfile,
   checkGoogleReviews,
@@ -342,16 +343,24 @@ function computeGapsIdentified(report) {
  * Aggregate competitor names from live platformResults only. No LLM web-search
  * fallback, no Perplexity backfill. Output rows carry only { name, description, website }
  * — no strengths, no reason.
+ *
+ * The searched firm is excluded via normalized same-firm comparison
+ * (case/suffix/diacritic-insensitive) so a firm listed as "Celtic Frozen
+ * Drinks Ltd" in the AI output is correctly filtered when registered as
+ * "Celtic Frozen Drinks" (and vice-versa). When a competitor entry carries
+ * its own website, the searched firm's domain is also excluded.
  */
-function aggregateCompetitors(platformResults, companyName) {
+function aggregateCompetitors(platformResults, companyName, firmWebsiteUrl) {
   if (!Array.isArray(platformResults) || platformResults.length === 0) return [];
-  const companyLower = companyName.toLowerCase();
   const freq = new Map();
   for (const pr of platformResults) {
     if (pr.error || !Array.isArray(pr.competitors) || pr.competitors.length === 0) continue;
     for (const entry of pr.competitors) {
       const compName = typeof entry === 'string' ? entry : entry?.name;
-      if (!compName || compName.toLowerCase().includes(companyLower)) continue;
+      if (!compName) continue;
+      if (isSameFirm(compName, companyName)) continue;
+      const compWebsite = typeof entry === 'object' ? entry?.website : null;
+      if (compWebsite && firmWebsiteUrl && isSameDomain(compWebsite, firmWebsiteUrl)) continue;
       const key = compName.trim().replace(/\s+/g, ' ');
       if (!isValidBusinessName(key)) continue;
       const existing = freq.get(key);
@@ -472,6 +481,7 @@ export async function buildPublicReport({
     category,
     city,
     categoryLabel,
+    websiteUrl: detectorResult.websiteUrl,
   }).catch((err) => {
     console.error('[AEO] Platform queries failed:', err.message);
     return [];
@@ -550,7 +560,7 @@ export async function buildPublicReport({
 
   const competitorsOnTendorAI = await countCompetitorsOnTendorAI({ category, city });
 
-  const competitors = aggregateCompetitors(platformResults, companyName);
+  const competitors = aggregateCompetitors(platformResults, companyName, detectorResult.websiteUrl);
   const aiRecommendations = competitors.map((c) => ({
     name: c.name,
     description: c.description,

--- a/tests/unit/aeoMentionDetection.test.js
+++ b/tests/unit/aeoMentionDetection.test.js
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the AEO free-report mention + competitor pipeline.
+ *
+ * The live bug (Celtic Frozen Drinks, Pontyclun): Perplexity returned the
+ * searched firm in its recommended list, but the report claimed "Mentioned by
+ * 0 of 5 platforms" AND listed the firm as its own #1 competitor. Root cause
+ * was a strict case-sensitive-with-suffix substring check that failed when
+ * the firm's stored name and the AI-output name differed by suffix (Ltd,
+ * Limited, etc.) or punctuation.
+ *
+ * These tests exercise the fixed pipeline end-to-end at the parser boundary:
+ *   - A firm appearing in a platform's recommended list must register as
+ *     mentioned (regardless of suffix variation / URL-only citation).
+ *   - A firm must never appear in its own competitor list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePlatformResponse } from '../../services/platformQuery/prompt.js';
+import {
+  normalizeCompanyName,
+  isCompanyMentioned,
+  isSameFirm,
+  extractDomainTokens,
+  isSameDomain,
+} from '../../services/platformQuery/nameMatch.js';
+
+describe('normalizeCompanyName', () => {
+  it('strips common UK company suffixes', () => {
+    expect(normalizeCompanyName('Celtic Frozen Drinks Ltd')).toBe('celtic frozen drinks');
+    expect(normalizeCompanyName('Celtic Frozen Drinks Limited')).toBe('celtic frozen drinks');
+    expect(normalizeCompanyName('Nutrivend Group')).toBe('nutrivend');
+    expect(normalizeCompanyName('Smith & Co')).toBe('smith');
+    expect(normalizeCompanyName('Smith LLP')).toBe('smith');
+  });
+
+  it('is case and diacritic insensitive', () => {
+    expect(normalizeCompanyName('CELTIC FROZEN DRINKS')).toBe('celtic frozen drinks');
+    expect(normalizeCompanyName('Café Müller')).toBe('cafe muller');
+  });
+
+  it('returns the same token for equivalent suffix variants', () => {
+    const a = normalizeCompanyName('Celtic Frozen Drinks');
+    const b = normalizeCompanyName('Celtic Frozen Drinks Ltd');
+    const c = normalizeCompanyName('celtic frozen drinks limited');
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('tolerates empty/missing input', () => {
+    expect(normalizeCompanyName('')).toBe('');
+    expect(normalizeCompanyName(null)).toBe('');
+    expect(normalizeCompanyName(undefined)).toBe('');
+  });
+});
+
+describe('isSameFirm', () => {
+  it('matches suffix-only differences in either direction', () => {
+    expect(isSameFirm('Celtic Frozen Drinks', 'Celtic Frozen Drinks Ltd')).toBe(true);
+    expect(isSameFirm('Celtic Frozen Drinks Ltd', 'Celtic Frozen Drinks')).toBe(true);
+  });
+
+  it('matches different case', () => {
+    expect(isSameFirm('celtic frozen drinks', 'Celtic Frozen Drinks')).toBe(true);
+  });
+
+  it('does not match unrelated firms sharing a word', () => {
+    expect(isSameFirm('Smith Solicitors', 'Smith & Jones Solicitors')).toBe(false);
+    expect(isSameFirm('The Nutrivend Group Limited', 'Celtic Frozen Drinks')).toBe(false);
+  });
+});
+
+describe('extractDomainTokens / isSameDomain', () => {
+  it('extracts registrable tokens from URLs', () => {
+    const tokens = extractDomainTokens('https://www.celticfrozendrinks.co.uk/about');
+    expect(tokens).toContain('celticfrozendrinks.co.uk');
+  });
+
+  it('handles bare hostnames', () => {
+    const tokens = extractDomainTokens('celticfrozendrinks.co.uk');
+    expect(tokens).toContain('celticfrozendrinks.co.uk');
+  });
+
+  it('compares two URLs to the same domain', () => {
+    expect(
+      isSameDomain(
+        'https://www.celticfrozendrinks.co.uk',
+        'http://celticfrozendrinks.co.uk/contact',
+      ),
+    ).toBe(true);
+    expect(
+      isSameDomain('https://nutrivend.com', 'https://celticfrozendrinks.co.uk'),
+    ).toBe(false);
+  });
+});
+
+describe('isCompanyMentioned', () => {
+  it('detects the firm when listed with suffix variation', () => {
+    const text =
+      'Recommended instead: Sun Magic Juices, Nutrivend, The Nutrivend Group Limited, Celtic Frozen Drinks';
+    expect(isCompanyMentioned(text, 'Celtic Frozen Drinks Ltd')).toBe(true);
+    expect(isCompanyMentioned(text, 'Celtic Frozen Drinks')).toBe(true);
+  });
+
+  it('detects the firm via URL citation alone', () => {
+    const text = 'See [1] https://celticfrozendrinks.co.uk for supplier details.';
+    expect(
+      isCompanyMentioned(text, 'Celtic Frozen Drinks Ltd', 'https://celticfrozendrinks.co.uk'),
+    ).toBe(true);
+  });
+
+  it('returns false when the firm is absent', () => {
+    const text = 'Try Sun Magic Juices and Nutrivend for soft-drink supply.';
+    expect(isCompanyMentioned(text, 'Celtic Frozen Drinks Ltd')).toBe(false);
+  });
+});
+
+describe('parsePlatformResponse — Issue 1 regression (mention detection)', () => {
+  it('marks the firm as mentioned when listed alongside competitors with suffix variation', () => {
+    const perplexityResponse = `Here are the frozen drinks suppliers in Pontyclun, UK:
+
+1. Sun Magic Juices - a specialist soft drinks producer
+2. Nutrivend - vending and drinks machines
+3. The Nutrivend Group Limited - vending group
+4. Celtic Frozen Drinks - local frozen drinks supplier
+5. Slush Puppie - frozen drinks brand
+`;
+    const parsed = parsePlatformResponse(perplexityResponse, 'Celtic Frozen Drinks Ltd');
+    expect(parsed.mentioned).toBe(true);
+    expect(parsed.position).toBe(4);
+  });
+
+  it('marks the firm as mentioned via URL citation alone (Perplexity inline source)', () => {
+    const response = `Here are some recommended suppliers:
+
+1. Sun Magic Juices - longstanding juice brand
+2. Nutrivend - vending specialist
+
+Source [1] https://celticfrozendrinks.co.uk/about`;
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks Ltd', {
+      websiteUrl: 'https://celticfrozendrinks.co.uk',
+    });
+    expect(parsed.mentioned).toBe(true);
+  });
+
+  it('still returns mentioned: false when the firm is genuinely absent', () => {
+    const response = `1. Sun Magic Juices - longstanding juice brand
+2. Nutrivend - vending specialist
+3. Slush Puppie - frozen drinks brand`;
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks Ltd');
+    expect(parsed.mentioned).toBe(false);
+  });
+
+  it('does not report a mention when the AI explicitly says it cannot find the firm', () => {
+    const response =
+      'I could not find Celtic Frozen Drinks in my results. Here are other suppliers: Sun Magic Juices, Nutrivend.';
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks Ltd');
+    expect(parsed.mentioned).toBe(false);
+  });
+});
+
+describe('parsePlatformResponse — Issue 2 regression (same-firm-as-competitor)', () => {
+  it('does not list the firm as its own competitor when listed with a suffix variant', () => {
+    const response = `Here are 5 recommended frozen drinks suppliers:
+
+1. Sun Magic Juices - specialist juice producer
+2. Nutrivend - vending and drinks machines
+3. Celtic Frozen Drinks Ltd - local frozen drinks supplier
+4. Slush Puppie - frozen drinks brand
+`;
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks');
+    const competitorNames = parsed.competitors.map((c) => c.name.toLowerCase());
+    for (const name of competitorNames) {
+      expect(name).not.toContain('celtic frozen drinks');
+    }
+  });
+
+  it('does not list the firm as its own competitor when the firm carries the suffix', () => {
+    const response = `Here are 5 recommended frozen drinks suppliers:
+
+1. Sun Magic Juices - specialist juice producer
+2. Nutrivend - vending and drinks machines
+3. Celtic Frozen Drinks - local frozen drinks supplier
+`;
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks Ltd');
+    const competitorNames = parsed.competitors.map((c) => c.name.toLowerCase());
+    for (const name of competitorNames) {
+      expect(name).not.toContain('celtic frozen drinks');
+    }
+  });
+
+  it('keeps unrelated firms in the competitor list', () => {
+    const response = `1. Sun Magic Juices - specialist juice producer
+2. Nutrivend - vending and drinks machines
+3. Celtic Frozen Drinks Ltd - local frozen drinks supplier
+`;
+    const parsed = parsePlatformResponse(response, 'Celtic Frozen Drinks');
+    const names = parsed.competitors.map((c) => c.name);
+    expect(names).toContain('Sun Magic Juices');
+    expect(names).toContain('Nutrivend');
+  });
+});


### PR DESCRIPTION
## Summary

Public AEO free report had two linked bugs surfaced by the Celtic Frozen Drinks / Pontyclun run:

1. **Mention detection missed the firm** even when a platform named them. The Perplexity row showed "Not recommended by Perplexity" while its own "Recommended instead" block contained the firm. Counter said "Mentioned by 0 of 5 platforms".
2. **Firm listed as its own competitor.** Comparison table header read "Celtic Frozen Drinks | Celtic Frozen Drinks"; intro copy said "Celtic Frozen Drinks does. You don't."; "Who AI Recommends Instead" had the searched firm at #1.

### Root cause

`parsePlatformResponse` used a strict case-sensitive-with-suffix substring check — `text.toLowerCase().includes(companyName.toLowerCase())` — for **both** the mention flag **and** the same-firm competitor-exclude guard. When the stored name and the AI-output name differed by a suffix ("Celtic Frozen Drinks" vs "Celtic Frozen Drinks Ltd"), case, or punctuation:

- `mentioned` → false (and the "Not recommended by X" label fires)
- the AI's rendering of the firm slipped past the exclude guard and landed in the competitor list

### Fix

New `services/platformQuery/nameMatch.js` reuses the PR #30 Places-match recipe:

- lowercase + NFD diacritic strip
- iterative UK / international company-form suffix strip (Ltd, Limited, LLP, PLC, Co, Group, Holdings, Services, & Co, & Sons, …)
- punctuation-tolerant substring comparison
- URL-citation fallback so Perplexity-style inline source links register as a mention when the firm's `websiteUrl` is threaded through

Both `parsePlatformResponse` (mention flag, position scan, snippet extraction, three competitor-list extractors) and `publicAeoReportBuilder.aggregateCompetitors` now use the shared `isCompanyMentioned` / `isSameFirm` helpers. Competitors with the same domain as the searched firm are also excluded.

Issue 3 (contradictory platform label) resolves automatically once `mentioned` is correct — the label is driven off that flag.

### Files

- `services/platformQuery/nameMatch.js` (new) — normalization + mention/same-firm/same-domain helpers
- `services/platformQuery/prompt.js` — use new helpers for mention check, position scan, snippet filter, and the three competitor-exclude guards; `parsePlatformResponse(text, name, { websiteUrl })`
- `services/platformQuery/{perplexity,chatgpt,claude,gemini,grok,meta}.js` — accept & forward `websiteUrl`
- `services/platformQuery/index.js` — `queryAllPlatforms` / `querySinglePlatform` thread `websiteUrl`
- `services/publicAeoReportBuilder.js` — pass `detectorResult.websiteUrl` into `queryAllPlatforms`; `aggregateCompetitors` uses `isSameFirm` + `isSameDomain`
- `services/aeoReportGenerator.js` — pass `websiteUrl` through for consistency (LLM subsystem)
- `tests/unit/aeoMentionDetection.test.js` (new) — 20 regression tests

## Test plan

- [x] `npx vitest run tests/unit/aeoMentionDetection.test.js` — 20/20 green
- [x] `node --check` on every modified file
- [ ] Re-run the Celtic Frozen Drinks report against the deployed branch and confirm: `mentioned === true` for Perplexity, firm absent from `competitors[]`, no "X does. You don't." intro naming the firm itself, "Not recommended by Perplexity" label flips off
- [ ] Sanity-check a firm that genuinely isn't mentioned (e.g. random made-up name) still scores `mentioned: false` and appears in no competitor list

https://claude.ai/code/session_01UfruZRoVmmukCzaQ32GnUC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfruZRoVmmukCzaQ32GnUC)_