### PR TITLE
feat(onboarding): track 7-item checklist + auto-detect 4 events

### DIFF
--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -262,6 +262,38 @@ const vendorSchema = new mongoose.Schema({
     }]
   },
 
+  // Onboarding checklist — 7-item granular state for the
+  // /vendor-dashboard/getting-started checklist UI. Distinct from the
+  // pre-existing coarse `account.onboardingCompleted` boolean above
+  // (which stays as-is for backward compatibility). Three items are
+  // vendor-tickable via PATCH /:vendorId/onboarding-checklist; the
+  // other four auto-detect from existing system events.
+  onboardingChecklist: {
+    type: new mongoose.Schema({
+      profileComplete: { type: Boolean, default: false },
+      profileCompleteAt: { type: Date, default: null },
+
+      firstProductAdded: { type: Boolean, default: false },
+      firstProductAddedAt: { type: Date, default: null },
+
+      firstAuditRun: { type: Boolean, default: false },
+      firstAuditRunAt: { type: Date, default: null },
+
+      schemaCallScheduled: { type: Boolean, default: false },
+      schemaCallScheduledAt: { type: Date, default: null },
+
+      firstPillarPostGenerated: { type: Boolean, default: false },
+      firstPillarPostGeneratedAt: { type: Date, default: null },
+
+      firstPrimaryDataAdded: { type: Boolean, default: false },
+      firstPrimaryDataAddedAt: { type: Date, default: null },
+
+      firstLiveAITestRun: { type: Boolean, default: false },
+      firstLiveAITestRunAt: { type: Date, default: null },
+    }, { _id: false }),
+    default: () => ({}),
+  },
+
   // Stripe & Subscription
   stripeCustomerId: { type: String, sparse: true, index: true },
   stripeSubscriptionId: { type: String, sparse: true },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "scan:mentions": "node scripts/weeklyAIMentionScan.js",
     "email:weekly": "node scripts/sendWeeklyVendorEmails.js",
     "generate:reports": "node scripts/generateBatchReports.js",
+    "smoke:onboarding": "node scripts/smoke-test-onboarding-flags.mjs",
     "clean": "rm -rf node_modules package-lock.json && npm install",
     "build": "echo \"No build step required for Node.js\""
   },

--- a/routes/vendorPostRoutes.js
+++ b/routes/vendorPostRoutes.js
@@ -403,6 +403,62 @@ router.post('/:vendorId/posts/generate', vendorAuth, async (req, res) => {
       plan: pillarSpec || null,
       pillar: pillar || null,
     });
+
+    // Auto-detect: onboarding checklist — firstPillarPostGenerated
+    // and firstPrimaryDataAdded. Only fires after the LLM call AND
+    // the JSON parse have succeeded — a failed generate doesn't
+    // trigger checklist progress.
+    //
+    // Each flag is written via an atomic updateOne whose query filters
+    // on the current state. If the flag is already true, the write
+    // is a no-op and the timestamp stays at the original first-time
+    // value (idempotent). The handler's vendor.findById doesn't select
+    // the checklist field, so we can't read-then-write — the query
+    // condition does the gating instead.
+    try {
+      const now = new Date();
+      const hasPillar = typeof pillar === 'string' && pillar.trim();
+      const hasPrimaryData = typeof primaryData === 'string' && primaryData.trim();
+      const writes = [];
+      if (hasPillar) {
+        writes.push(Vendor.updateOne(
+          {
+            _id: vendorId,
+            $or: [
+              { 'onboardingChecklist.firstPillarPostGenerated': { $ne: true } },
+              { 'onboardingChecklist.firstPillarPostGenerated': { $exists: false } },
+            ],
+          },
+          {
+            $set: {
+              'onboardingChecklist.firstPillarPostGenerated': true,
+              'onboardingChecklist.firstPillarPostGeneratedAt': now,
+            },
+          },
+        ));
+      }
+      if (hasPrimaryData) {
+        writes.push(Vendor.updateOne(
+          {
+            _id: vendorId,
+            $or: [
+              { 'onboardingChecklist.firstPrimaryDataAdded': { $ne: true } },
+              { 'onboardingChecklist.firstPrimaryDataAdded': { $exists: false } },
+            ],
+          },
+          {
+            $set: {
+              'onboardingChecklist.firstPrimaryDataAdded': true,
+              'onboardingChecklist.firstPrimaryDataAddedAt': now,
+            },
+          },
+        ));
+      }
+      if (writes.length) await Promise.all(writes);
+    } catch (checklistErr) {
+      console.error('[OnboardingChecklist] post-generate detect failed for vendor',
+        vendorId, checklistErr?.message || checklistErr);
+    }
   } catch (error) {
     console.error('[PostGenerate] Error:', error.message);
     console.error('[PostGenerate] Stack:', error.stack);

--- a/routes/vendorServiceRoutes.js
+++ b/routes/vendorServiceRoutes.js
@@ -237,6 +237,31 @@ router.post(
       success: true,
       data: doc.toObject(),
     });
+
+    // Auto-detect: onboarding checklist — firstProductAdded.
+    // Fire-and-forget; the response has already been sent. Same flag
+    // as the legacy POST /api/vendors/products path — a vendor's
+    // first product or service event flips the same checklist item.
+    try {
+      await Vendor.updateOne(
+        {
+          _id: vendor._id,
+          $or: [
+            { 'onboardingChecklist.firstProductAdded': { $ne: true } },
+            { 'onboardingChecklist.firstProductAdded': { $exists: false } },
+          ],
+        },
+        {
+          $set: {
+            'onboardingChecklist.firstProductAdded': true,
+            'onboardingChecklist.firstProductAddedAt': new Date(),
+          },
+        },
+      );
+    } catch (checklistErr) {
+      console.error('[OnboardingChecklist] firstProductAdded detect failed for vendor',
+        vendor._id, checklistErr?.message || checklistErr);
+    }
   }),
 );
 

--- a/routes/vendorUploadRoutes.js
+++ b/routes/vendorUploadRoutes.js
@@ -55,14 +55,14 @@ export function checkProfileCompleteness(vendor) {
     if (!vendor.description || String(vendor.description).trim().length < 50) return false;
     if (!vendor.vendorType) return false;
     const hasSpecialism =
-        (Array.isArray(vendor.practiceAreas)
+        (Array.isArray(vendor.specialisms)
+            && vendor.specialisms.some((s) => typeof s === 'string' && s.trim()))
+        || (Array.isArray(vendor.practiceAreas)
             && vendor.practiceAreas.some((s) => typeof s === 'string' && s.trim()))
         || (Array.isArray(vendor.industrySpecialisms)
             && vendor.industrySpecialisms.some((s) => typeof s === 'string' && s.trim()))
         || (Array.isArray(vendor.businessProfile?.specializations)
-            && vendor.businessProfile.specializations.some((s) => typeof s === 'string' && s.trim()))
-        || (Array.isArray(vendor.specialisms)
-            && vendor.specialisms.some((s) => typeof s === 'string' && s.trim()));
+            && vendor.businessProfile.specializations.some((s) => typeof s === 'string' && s.trim()));
     return Boolean(hasSpecialism);
 }
 

--- a/routes/vendorUploadRoutes.js
+++ b/routes/vendorUploadRoutes.js
@@ -28,6 +28,44 @@ import { runSingleVendorScan } from "../services/aiMentionScanner.js";
 const router = express.Router();
 const { JWT_SECRET } = process.env;
 
+// ─── Onboarding checklist support ────────────────────────────────────
+// Items the vendor may self-tick via PATCH. Everything else on the
+// checklist is auto-detected from system events and PATCH rejects it.
+export const ONBOARDING_TICKABLE_ITEMS = new Set([
+    'schemaCallScheduled',
+    'firstAuditRun',
+    'firstLiveAITestRun',
+]);
+export const ONBOARDING_AUTO_DETECTED_ITEMS = new Set([
+    'profileComplete',
+    'firstProductAdded',
+    'firstPillarPostGenerated',
+    'firstPrimaryDataAdded',
+]);
+
+/**
+ * Profile-completeness threshold for the getting-started checklist.
+ * Returns true when ALL five conditions are satisfied. Exported for
+ * direct unit testing.
+ */
+export function checkProfileCompleteness(vendor) {
+    if (!vendor) return false;
+    if (!vendor.company || !String(vendor.company).trim()) return false;
+    if (!vendor.location?.city || !String(vendor.location.city).trim()) return false;
+    if (!vendor.description || String(vendor.description).trim().length < 50) return false;
+    if (!vendor.vendorType) return false;
+    const hasSpecialism =
+        (Array.isArray(vendor.practiceAreas)
+            && vendor.practiceAreas.some((s) => typeof s === 'string' && s.trim()))
+        || (Array.isArray(vendor.industrySpecialisms)
+            && vendor.industrySpecialisms.some((s) => typeof s === 'string' && s.trim()))
+        || (Array.isArray(vendor.businessProfile?.specializations)
+            && vendor.businessProfile.specializations.some((s) => typeof s === 'string' && s.trim()))
+        || (Array.isArray(vendor.specialisms)
+            && vendor.specialisms.some((s) => typeof s === 'string' && s.trim()));
+    return Boolean(hasSpecialism);
+}
+
 if (!JWT_SECRET) {
     console.error('âŒ ERROR: Missing JWT_SECRET in environment variables.');
     process.exit(1);
@@ -592,6 +630,24 @@ router.put('/profile', vendorAuth, async (req, res) => {
             console.error('[FirstScan] Failed for vendor', updatedVendor._id, err.message);
           });
         }
+
+        // Auto-detect: onboarding checklist — profileComplete.
+        // Wrapped so a checklist write failure cannot break the
+        // already-completed profile update.
+        try {
+          if (checkProfileCompleteness(updatedVendor)
+              && !updatedVendor.onboardingChecklist?.profileComplete) {
+            await Vendor.findByIdAndUpdate(updatedVendor._id, {
+              $set: {
+                'onboardingChecklist.profileComplete': true,
+                'onboardingChecklist.profileCompleteAt': new Date(),
+              },
+            });
+          }
+        } catch (checklistErr) {
+          console.error('[OnboardingChecklist] profileComplete detect failed for vendor',
+            updatedVendor._id, checklistErr.message);
+        }
     } catch (error) {
         console.error('Error updating vendor profile:', error.message);
         res.status(500).json({
@@ -611,6 +667,77 @@ router.post('/onboarding-complete', vendorAuth, async (req, res) => {
         res.json({ success: true });
     } catch (error) {
         res.status(500).json({ message: 'Failed to update onboarding status.' });
+    }
+});
+
+// PATCH /api/vendors/:vendorId/onboarding-checklist
+//
+// Vendor self-tick endpoint for the three checklist items the system
+// can't auto-detect (schemaCallScheduled, firstAuditRun,
+// firstLiveAITestRun). Auto-detected items reject with 400.
+//
+// Idempotent: a second tick on an already-true item leaves the
+// timestamp untouched and returns 200 with the existing state.
+router.patch('/:vendorId/onboarding-checklist', vendorAuth, async (req, res) => {
+    try {
+        const { vendorId } = req.params;
+        if (req.vendorId?.toString() !== vendorId) {
+            return res.status(403).json({ success: false, error: 'Not authorised' });
+        }
+
+        const { item } = req.body || {};
+        if (!item || typeof item !== 'string') {
+            return res.status(400).json({
+                success: false,
+                error: 'Request body must include `item` (string).',
+            });
+        }
+
+        if (ONBOARDING_AUTO_DETECTED_ITEMS.has(item)) {
+            return res.status(400).json({
+                success: false,
+                error: `Item is auto-detected and cannot be manually set: ${item}`,
+            });
+        }
+        if (!ONBOARDING_TICKABLE_ITEMS.has(item)) {
+            return res.status(400).json({
+                success: false,
+                error: `Unknown checklist item: ${item}`,
+            });
+        }
+
+        const vendor = await Vendor.findById(vendorId).select('onboardingChecklist');
+        if (!vendor) {
+            return res.status(404).json({ success: false, error: 'Vendor not found' });
+        }
+
+        // Idempotent path: already true → return as-is, do not touch timestamp.
+        if (vendor.onboardingChecklist?.[item] === true) {
+            return res.json({
+                success: true,
+                onboardingChecklist: vendor.onboardingChecklist,
+            });
+        }
+
+        // First-time tick: set boolean + timestamp.
+        const updated = await Vendor.findByIdAndUpdate(
+            vendorId,
+            {
+                $set: {
+                    [`onboardingChecklist.${item}`]: true,
+                    [`onboardingChecklist.${item}At`]: new Date(),
+                },
+            },
+            { new: true, select: 'onboardingChecklist' },
+        );
+
+        return res.json({
+            success: true,
+            onboardingChecklist: updated.onboardingChecklist,
+        });
+    } catch (error) {
+        console.error('[OnboardingChecklist] PATCH failed:', error.message);
+        return res.status(500).json({ success: false, error: 'Failed to update checklist.' });
     }
 });
 
@@ -1390,6 +1517,29 @@ router.post("/products", async (req, res) => {
             data: product,
             remainingSlots: limit === Infinity ? null : limit - currentCount - 1
         });
+
+        // Auto-detect: onboarding checklist — firstProductAdded.
+        // Fire-and-forget; the response has already been sent.
+        try {
+            await Vendor.updateOne(
+                {
+                    _id: vendorId,
+                    $or: [
+                        { 'onboardingChecklist.firstProductAdded': { $ne: true } },
+                        { 'onboardingChecklist.firstProductAdded': { $exists: false } },
+                    ],
+                },
+                {
+                    $set: {
+                        'onboardingChecklist.firstProductAdded': true,
+                        'onboardingChecklist.firstProductAddedAt': new Date(),
+                    },
+                },
+            );
+        } catch (checklistErr) {
+            console.error('[OnboardingChecklist] firstProductAdded detect failed for vendor',
+                vendorId, checklistErr.message);
+        }
     } catch (error) {
         console.error("Error creating product:", error);
         if (error.name === 'ValidationError') {

--- a/scripts/smoke-test-onboarding-flags.mjs
+++ b/scripts/smoke-test-onboarding-flags.mjs
@@ -1,0 +1,150 @@
+/**
+ * Manual post-deploy smoke-test for the onboarding-checklist
+ * auto-detection wired into POST /api/vendors/:vendorId/posts/generate.
+ *
+ * NOT part of the automated test suite — vitest covers the same logic
+ * with mocks in tests/unit/onboardingChecklist.test.js. This script
+ * verifies the live integration end-to-end against a real DB and a
+ * real Anthropic call after a deploy.
+ *
+ * Set up a test vendor before running:
+ *   - vendorType: 'solicitor'
+ *   - tier: 'pro' (or any paid tier)
+ *   - location.city: any string
+ *   - practiceAreas: ['Conveyancing']  (so the pillar lookup works)
+ *   - onboardingChecklist.firstPillarPostGenerated: false
+ *   - onboardingChecklist.firstPrimaryDataAdded:  false
+ *
+ * Usage:
+ *   MONGODB_URI=mongodb+srv://... \
+ *   ANTHROPIC_API_KEY=sk-... \
+ *   JWT_SECRET=... \
+ *   VENDOR_ID=<bson-id> \
+ *   BASE_URL=http://localhost:5000 \
+ *     npm run smoke:onboarding
+ *
+ * Tests performed:
+ *   1. First generate — both flags should flip to true with recent
+ *      timestamps (within 60s).
+ *   2. Second generate (after a 2s wait) — both flags stay true and
+ *      both timestamps are unchanged from Test 1 (idempotency).
+ *
+ * Requires the backend server to be running and reachable at BASE_URL.
+ * The script connects to Mongo directly to read the vendor doc before
+ * and after each request.
+ */
+
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import Vendor from '../models/Vendor.js';
+
+const {
+  MONGODB_URI,
+  JWT_SECRET,
+  VENDOR_ID,
+  BASE_URL = 'http://localhost:5000',
+} = process.env;
+
+if (!MONGODB_URI || !JWT_SECRET || !VENDOR_ID) {
+  console.error('Missing required env: MONGODB_URI, JWT_SECRET, VENDOR_ID');
+  console.error('See header comment for setup.');
+  process.exit(1);
+}
+
+await mongoose.connect(MONGODB_URI);
+const token = jwt.sign({ vendorId: VENDOR_ID }, JWT_SECRET);
+
+const body = {
+  topic: 'How much does conveyancing cost in Cardiff in 2026?',
+  pillar: 'costs-fees',
+  topicIndex: 0,
+  primaryData:
+    'Based on our last 247 conveyancing transactions in Cardiff, the typical all-in cost is £1,850.',
+};
+
+async function generate() {
+  const res = await fetch(`${BASE_URL}/api/vendors/${VENDOR_ID}/posts/generate`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+async function readChecklist() {
+  const v = await Vendor.findById(VENDOR_ID).select('onboardingChecklist').lean();
+  return v?.onboardingChecklist || {};
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const recent = (d) => d && (Date.now() - new Date(d).getTime()) < 60_000;
+const sameTs = (a, b) => a && b && new Date(a).getTime() === new Date(b).getTime();
+
+let exitCode = 0;
+
+// ─── Test 1 ─────────────────────────────────────────────────────────
+console.log('--- Test 1: first generate, both flags should flip ---');
+const before = await readChecklist();
+console.log('before:', {
+  firstPillarPostGenerated: before.firstPillarPostGenerated,
+  firstPrimaryDataAdded: before.firstPrimaryDataAdded,
+});
+if (before.firstPillarPostGenerated || before.firstPrimaryDataAdded) {
+  console.error('Pre-condition failed: both flags must be false. Reset and re-run.');
+  await mongoose.disconnect();
+  process.exit(1);
+}
+
+const r1 = await generate();
+console.log('response status:', r1.status);
+console.log('response keys:', r1.json ? Object.keys(r1.json) : '(no body)');
+
+await sleep(500); // give the fire-and-forget updateOne a moment
+const after1 = await readChecklist();
+console.log('after Test 1:', {
+  firstPillarPostGenerated: after1.firstPillarPostGenerated,
+  firstPillarPostGeneratedAt: after1.firstPillarPostGeneratedAt,
+  firstPrimaryDataAdded: after1.firstPrimaryDataAdded,
+  firstPrimaryDataAddedAt: after1.firstPrimaryDataAddedAt,
+});
+
+const test1Pass =
+  r1.status === 200
+  && after1.firstPillarPostGenerated === true
+  && recent(after1.firstPillarPostGeneratedAt)
+  && after1.firstPrimaryDataAdded === true
+  && recent(after1.firstPrimaryDataAddedAt);
+console.log(test1Pass ? 'TEST 1: PASS' : 'TEST 1: FAIL');
+if (!test1Pass) exitCode = 1;
+
+const pillarAt1 = after1.firstPillarPostGeneratedAt;
+const primaryAt1 = after1.firstPrimaryDataAddedAt;
+
+// ─── Test 2 ─────────────────────────────────────────────────────────
+console.log('\n--- Test 2: second generate, timestamps must NOT change ---');
+await sleep(2_000);
+const r2 = await generate();
+console.log('response status:', r2.status);
+
+await sleep(500);
+const after2 = await readChecklist();
+console.log('after Test 2:', {
+  firstPillarPostGenerated: after2.firstPillarPostGenerated,
+  firstPillarPostGeneratedAt: after2.firstPillarPostGeneratedAt,
+  firstPrimaryDataAdded: after2.firstPrimaryDataAdded,
+  firstPrimaryDataAddedAt: after2.firstPrimaryDataAddedAt,
+});
+
+const test2Pass =
+  r2.status === 200
+  && after2.firstPillarPostGenerated === true
+  && after2.firstPrimaryDataAdded === true
+  && sameTs(after2.firstPillarPostGeneratedAt, pillarAt1)
+  && sameTs(after2.firstPrimaryDataAddedAt, primaryAt1);
+console.log(test2Pass ? 'TEST 2: PASS' : 'TEST 2: FAIL');
+if (!test2Pass) exitCode = 1;
+
+await mongoose.disconnect();
+console.log(`\nFinal: ${exitCode === 0 ? 'PASS' : 'FAIL'}`);
+process.exit(exitCode);

--- a/tests/unit/onboardingChecklist.test.js
+++ b/tests/unit/onboardingChecklist.test.js
@@ -1,0 +1,359 @@
+/**
+ * Onboarding checklist tracking — tests for the PATCH endpoint, the
+ * profile-completeness helper, and the post-generate auto-detection.
+ *
+ * No live LLM calls and no live DB. Vendor.findById is stubbed via
+ * vi.spyOn; the Anthropic SDK is mocked via vi.mock so the
+ * post-generate handler completes its happy path without network.
+ *
+ * Harness mirrors tests/unit/contentLibrary.test.js: env set first,
+ * dynamic imports of route files, in-process Express via fetch, real
+ * JWT signed against a throwaway secret.
+ */
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-onboarding';
+process.env.ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'test-admin-secret';
+process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || 'test-anthropic-key';
+// vendorUploadRoutes transitively imports a logger that requires
+// the standard backend env block. Set throwaway values for tests.
+process.env.MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/test';
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-openai-key';
+process.env.PORT = process.env.PORT || '0';
+process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import http from 'http';
+import express from 'express';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+
+// Mock the Anthropic SDK before any import that pulls it in. The
+// generate handler does `await import('@anthropic-ai/sdk')` inside
+// the request, but vi.mock is hoisted and intercepts the dynamic
+// import too.
+vi.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = vi.fn(async () => ({
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        title: 'A test post',
+        body: 'Body of the test post.',
+        linkedInText: 'LinkedIn variant.',
+        facebookText: 'Facebook variant.',
+      }),
+    }],
+  }));
+  class Anthropic {
+    constructor() {
+      this.messages = { create: mockCreate };
+    }
+  }
+  return { default: Anthropic };
+});
+
+// Dynamic imports — env set first so vendorAuth's JWT_SECRET assert passes.
+const vendorUploadRoutes = (await import('../../routes/vendorUploadRoutes.js')).default;
+const { checkProfileCompleteness, ONBOARDING_TICKABLE_ITEMS, ONBOARDING_AUTO_DETECTED_ITEMS } =
+  await import('../../routes/vendorUploadRoutes.js');
+const vendorPostRoutes = (await import('../../routes/vendorPostRoutes.js')).default;
+const { default: Vendor } = await import('../../models/Vendor.js');
+
+// ───────────────────────── helpers ────────────────────────────────────
+
+const authedVendorId = new mongoose.Types.ObjectId();
+const otherVendorId = new mongoose.Types.ObjectId();
+
+let currentVendor;
+let updateOneCalls;
+
+function defaultVendor(overrides = {}) {
+  return {
+    _id: authedVendorId,
+    company: 'Test Solicitors LLP',
+    vendorType: 'solicitor',
+    tier: 'pro',
+    status: 'active',
+    email: 'test@example.com',
+    name: 'Test',
+    companyName: 'Test Solicitors LLP',
+    location: { city: 'Manchester' },
+    practiceAreas: ['Conveyancing'],
+    description: 'A long-enough description so that the profile-completeness threshold treats this vendor as complete.',
+    onboardingChecklist: {
+      profileComplete: false,
+      firstProductAdded: false,
+      firstAuditRun: false,
+      schemaCallScheduled: false,
+      firstPillarPostGenerated: false,
+      firstPrimaryDataAdded: false,
+      firstLiveAITestRun: false,
+    },
+    ...overrides,
+  };
+}
+
+let server;
+let baseUrl;
+let token;
+
+beforeAll(async () => {
+  token = jwt.sign({ vendorId: String(authedVendorId) }, process.env.JWT_SECRET);
+
+  vi.spyOn(Vendor, 'findById').mockImplementation(() => {
+    // Mongoose Query objects are thenable, and any chain method like
+    // .select(), .lean(), .populate() also returns a thenable. The
+    // route awaits both `findById()` and `findById().select(...)`, so
+    // every link in the chain has to resolve to the vendor.
+    const value = () => ({ ...currentVendor });
+    const chain = {
+      lean: async () => value(),
+      exec: async () => value(),
+      then: (resolve) => resolve(value()),
+      select: () => chain,
+      populate: () => chain,
+    };
+    return chain;
+  });
+  vi.spyOn(Vendor, 'findByIdAndUpdate').mockImplementation((_id, update) => {
+    const $set = update?.$set || {};
+    for (const [k, v] of Object.entries($set)) {
+      if (k.startsWith('onboardingChecklist.')) {
+        const field = k.slice('onboardingChecklist.'.length);
+        currentVendor.onboardingChecklist = currentVendor.onboardingChecklist || {};
+        currentVendor.onboardingChecklist[field] = v;
+      }
+    }
+    return { lean: async () => ({ ...currentVendor }), then: (r) => r({ ...currentVendor }) };
+  });
+  vi.spyOn(Vendor, 'updateOne').mockImplementation(async (filter, update) => {
+    updateOneCalls.push({ filter, update });
+    // Apply if filter matches (we only test the $or "not yet set" filter shape).
+    const id = filter._id;
+    if (String(id) !== String(currentVendor._id)) return { matchedCount: 0, modifiedCount: 0 };
+    const orClauses = filter.$or || [];
+    if (orClauses.length) {
+      // Each clause looks like { 'onboardingChecklist.X': { $ne: true } } or { ...: { $exists: false } }
+      const clauseField = Object.keys(orClauses[0])[0];
+      const fieldName = clauseField.split('.').pop();
+      const currentValue = currentVendor.onboardingChecklist?.[fieldName];
+      if (currentValue === true) return { matchedCount: 0, modifiedCount: 0 };
+    }
+    const $set = update?.$set || {};
+    for (const [k, v] of Object.entries($set)) {
+      if (k.startsWith('onboardingChecklist.')) {
+        const field = k.slice('onboardingChecklist.'.length);
+        currentVendor.onboardingChecklist = currentVendor.onboardingChecklist || {};
+        currentVendor.onboardingChecklist[field] = v;
+      }
+    }
+    return { matchedCount: 1, modifiedCount: 1 };
+  });
+  // vendorAuth fire-and-forget last-activity updater.
+  vi.spyOn(Vendor.prototype, 'save').mockImplementation(async function () { return this; });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/vendors', vendorUploadRoutes);
+  app.use('/api/vendors', vendorPostRoutes);
+
+  server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  currentVendor = defaultVendor();
+  updateOneCalls = [];
+});
+
+async function patch(path, body, { withToken = true } = {}) {
+  const headers = { 'content-type': 'application/json' };
+  if (withToken) headers.authorization = `Bearer ${token}`;
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'PATCH', headers, body: JSON.stringify(body),
+  });
+  let json = null; try { json = await res.json(); } catch {}
+  return { status: res.status, body: json };
+}
+
+async function postGenerate(body) {
+  const res = await fetch(`${baseUrl}/api/vendors/${authedVendorId}/posts/generate`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  let json = null; try { json = await res.json(); } catch {}
+  return { status: res.status, body: json };
+}
+
+// Allow the post-generate fire-and-forget checklist write to complete
+// before the test asserts on it.
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// ───────────────────────── tests ──────────────────────────────────────
+
+describe('PATCH /api/vendors/:vendorId/onboarding-checklist', () => {
+  it('returns 401 without auth', async () => {
+    const r = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'schemaCallScheduled' }, { withToken: false });
+    expect(r.status).toBe(401);
+  });
+
+  it('returns 403 cross-vendor (req.vendorId differs from :vendorId)', async () => {
+    const r = await patch(`/api/vendors/${otherVendorId}/onboarding-checklist`,
+      { item: 'schemaCallScheduled' });
+    expect(r.status).toBe(403);
+    expect(r.body?.error).toMatch(/not authorised/i);
+  });
+
+  it('returns 400 for an unknown item', async () => {
+    const r = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'somethingMadeUp' });
+    expect(r.status).toBe(400);
+    expect(r.body?.error).toMatch(/unknown checklist item/i);
+  });
+
+  it('returns 400 for an auto-detected item (firstPillarPostGenerated)', async () => {
+    const r = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'firstPillarPostGenerated' });
+    expect(r.status).toBe(400);
+    expect(r.body?.error).toMatch(/auto-detected/i);
+  });
+
+  it('returns 200 and ticks a valid item with timestamp', async () => {
+    const r = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'schemaCallScheduled' });
+    expect(r.status).toBe(200);
+    expect(r.body?.success).toBe(true);
+    expect(r.body?.onboardingChecklist?.schemaCallScheduled).toBe(true);
+    expect(r.body?.onboardingChecklist?.schemaCallScheduledAt).toBeTruthy();
+  });
+
+  it('is idempotent — second tick does not update the timestamp', async () => {
+    // First tick.
+    const r1 = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'schemaCallScheduled' });
+    expect(r1.status).toBe(200);
+    const firstAt = r1.body.onboardingChecklist.schemaCallScheduledAt;
+
+    // Second tick on the same item.
+    const r2 = await patch(`/api/vendors/${authedVendorId}/onboarding-checklist`,
+      { item: 'schemaCallScheduled' });
+    expect(r2.status).toBe(200);
+    expect(r2.body.onboardingChecklist.schemaCallScheduled).toBe(true);
+    expect(r2.body.onboardingChecklist.schemaCallScheduledAt).toBe(firstAt);
+  });
+});
+
+describe('checkProfileCompleteness', () => {
+  it('returns false for an incomplete vendor (description too short)', () => {
+    const v = defaultVendor({ description: 'too short' });
+    expect(checkProfileCompleteness(v)).toBe(false);
+  });
+
+  it('returns false when vendor has no specialism field set', () => {
+    const v = defaultVendor({
+      practiceAreas: [], industrySpecialisms: [], specialisms: [],
+      businessProfile: { specializations: [] },
+    });
+    expect(checkProfileCompleteness(v)).toBe(false);
+  });
+
+  it('returns false when company is missing', () => {
+    const v = defaultVendor({ company: '' });
+    expect(checkProfileCompleteness(v)).toBe(false);
+  });
+
+  it('returns true when all five conditions are met (practiceAreas)', () => {
+    const v = defaultVendor();
+    expect(checkProfileCompleteness(v)).toBe(true);
+  });
+
+  it('returns true via industrySpecialisms when practiceAreas absent', () => {
+    const v = defaultVendor({ practiceAreas: [], industrySpecialisms: ['Tech'] });
+    expect(checkProfileCompleteness(v)).toBe(true);
+  });
+
+  it('returns true via businessProfile.specializations when both arrays absent', () => {
+    const v = defaultVendor({
+      practiceAreas: [],
+      industrySpecialisms: [],
+      businessProfile: { specializations: ['Healthcare'] },
+    });
+    expect(checkProfileCompleteness(v)).toBe(true);
+  });
+});
+
+describe('post-generate auto-detection', () => {
+  it('flags firstPillarPostGenerated when the request includes a pillar', async () => {
+    const r = await postGenerate({
+      topic: 'How much does conveyancing cost in Manchester in 2026?',
+      pillar: 'costs-fees',
+      topicIndex: 0,
+    });
+    expect(r.status).toBe(200);
+    await tick();
+    expect(currentVendor.onboardingChecklist.firstPillarPostGenerated).toBe(true);
+    expect(currentVendor.onboardingChecklist.firstPillarPostGeneratedAt).toBeInstanceOf(Date);
+  });
+
+  it('does NOT flag firstPrimaryDataAdded when primaryData is empty / whitespace', async () => {
+    const r = await postGenerate({
+      topic: 'A topic with no primary data',
+      pillar: 'costs-fees',
+      primaryData: '   ',
+    });
+    expect(r.status).toBe(200);
+    await tick();
+    expect(currentVendor.onboardingChecklist.firstPrimaryDataAdded).toBe(false);
+  });
+
+  it('flags firstPrimaryDataAdded when primaryData is non-empty', async () => {
+    const r = await postGenerate({
+      topic: 'A topic with primary data',
+      pillar: 'costs-fees',
+      primaryData: 'Our average conveyancing fee in 2025 was £950 across 247 cases.',
+    });
+    expect(r.status).toBe(200);
+    await tick();
+    expect(currentVendor.onboardingChecklist.firstPrimaryDataAdded).toBe(true);
+    expect(currentVendor.onboardingChecklist.firstPrimaryDataAddedAt).toBeInstanceOf(Date);
+  });
+
+  it('is idempotent — already-true firstPillarPostGenerated keeps its original timestamp', async () => {
+    // Pre-stamp the flag on the in-memory vendor.
+    const originalAt = new Date('2026-01-01T00:00:00Z');
+    currentVendor.onboardingChecklist.firstPillarPostGenerated = true;
+    currentVendor.onboardingChecklist.firstPillarPostGeneratedAt = originalAt;
+
+    const r = await postGenerate({
+      topic: 'Another pillar post',
+      pillar: 'process-timelines',
+    });
+    expect(r.status).toBe(200);
+    await tick();
+
+    // Flag stays true; timestamp must not have been overwritten.
+    expect(currentVendor.onboardingChecklist.firstPillarPostGenerated).toBe(true);
+    expect(currentVendor.onboardingChecklist.firstPillarPostGeneratedAt).toBe(originalAt);
+
+    // The conditional updateOne should have been issued, but the
+    // mock's filter check should have rejected it — modifiedCount 0.
+    const pillarWrite = updateOneCalls.find((c) =>
+      Object.keys(c.update?.$set || {}).includes('onboardingChecklist.firstPillarPostGenerated'));
+    expect(pillarWrite).toBeTruthy();
+  });
+
+  it('exposes ONBOARDING_TICKABLE_ITEMS and ONBOARDING_AUTO_DETECTED_ITEMS as the four-and-three split', () => {
+    expect(ONBOARDING_TICKABLE_ITEMS.size).toBe(3);
+    expect(ONBOARDING_AUTO_DETECTED_ITEMS.size).toBe(4);
+    for (const a of ONBOARDING_TICKABLE_ITEMS) {
+      expect(ONBOARDING_AUTO_DETECTED_ITEMS.has(a)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Replaces the frontend's hardcoded `done: false` flags on `/vendor-dashboard/getting-started` with real Mongo-backed state. The new `onboardingChecklist` subdocument has 7 Boolean+timestamp pairs; **3 are vendor-tickable via PATCH**, **4 auto-detect** from existing system events.

Backend only. No frontend work in this PR. The frontend reads via the existing `GET /api/vendors/profile` (returns the full vendor doc) — the new field appears automatically.

References: PR #35 (v7 generator + pillar library), commit `2006c32` (frontend's three new hardcoded checklist items).

## Files changed

| File | Δ |
|---|---|
| `models/Vendor.js` | +32 — new `onboardingChecklist` subdocument |
| `routes/vendorUploadRoutes.js` | +150 — `checkProfileCompleteness` helper, two exported sets, PATCH endpoint, profile-complete auto-detect, first-product auto-detect |
| `routes/vendorServiceRoutes.js` | +25 — first-service auto-detect on POST `/` |
| `routes/vendorPostRoutes.js` | +56 — pillar / primaryData auto-detect on `posts/generate` |
| `tests/unit/onboardingChecklist.test.js` | NEW — 17 vitest cases |

## The 7 checklist items

| Item | Vendor-tickable? | Auto-detect trigger |
|---|---|---|
| `profileComplete` | no | `PUT /api/vendors/profile` save, when threshold met |
| `firstProductAdded` | no | `POST /api/vendors/products` (legacy) **or** `POST /api/vendor-services` (schema-first) |
| `firstAuditRun` | **yes** | — |
| `schemaCallScheduled` | **yes** | — |
| `firstPillarPostGenerated` | no | `POST /api/vendors/:vendorId/posts/generate` when body includes `pillar` |
| `firstPrimaryDataAdded` | no | same handler when body includes non-empty `primaryData` |
| `firstLiveAITestRun` | **yes** | — |

Each item has a paired `<item>At` Date field, populated on first transition only — second writes are no-ops via atomic conditional `updateOne` filters.

## New endpoint

```
PATCH /api/vendors/:vendorId/onboarding-checklist
Auth: vendorAuth + req.vendorId === :vendorId
Body: { item: "schemaCallScheduled" | "firstAuditRun" | "firstLiveAITestRun" }
```

| Situation | Response |
|---|---|
| No auth | `401` |
| `req.vendorId !== :vendorId` | `403 "Not authorised"` |
| `item` missing or non-string | `400 "Request body must include `item` (string)"` |
| `item` is auto-detected | `400 "Item is auto-detected and cannot be manually set: <item>"` |
| `item` is unknown | `400 "Unknown checklist item: <item>"` |
| Tickable item, currently false | `200` with `{ success: true, onboardingChecklist }` — flag flipped, timestamp set |
| Tickable item, already true | `200` with `{ success: true, onboardingChecklist }` — **timestamp preserved** |

No un-tick path. Admin reset is out of scope.

## Auto-detection — the four wired triggers

### 1. `profileComplete` — `PUT /api/vendors/profile`

Helper `checkProfileCompleteness(vendor)` (exported) — ALL five conditions required:

- `vendor.company` non-empty
- `vendor.location.city` non-empty
- `vendor.description.trim().length >= 50`
- `vendor.vendorType` set
- At least one non-empty entry across `practiceAreas` / `industrySpecialisms` / `businessProfile.specializations` / `specialisms`

Wired after the existing first-AI-mention-scan fire-and-forget block. Wrapped in `try/catch` so a checklist failure can't break the profile save. Only writes when threshold is met AND flag is currently false.

### 2. `firstProductAdded` — two paths

Wired in BOTH product-creation endpoints because vendors split between them:

- `POST /api/vendors/products` (legacy, vendorUploadRoutes:1535+)
- `POST /api/vendor-services` (schema-first, vendorServiceRoutes:241+)

Both use the same atomic conditional `updateOne` — query filters on `firstProductAdded != true OR field absent`. Already-true → no-op, timestamp preserved.

Both fire AFTER `res.json` (response already sent), wrapped in `try/catch` — checklist failure cannot fail the create.

### 3 + 4. `firstPillarPostGenerated` + `firstPrimaryDataAdded` — `posts/generate`

Fires AFTER the LLM call AND the JSON parse have both succeeded — a failed generate doesn't trigger checklist progress.

The handler's existing `Vendor.findById(...).select('tier vendorType company location.city')` doesn't include `onboardingChecklist`, so we can't read-then-write. Each flag uses an atomic conditional `updateOne` whose query gates on the current state — no extra read, true idempotency. Both flags evaluated in one try/catch; if both fire, two parallel writes via `Promise.all`.

- `pillar` → set if `req.body.pillar` is a non-empty string
- `primaryData` → set if `req.body.primaryData` is a non-empty trimmed string

## Test coverage (17 cases)

```
PATCH endpoint:
  ✓ 401 without auth
  ✓ 403 cross-vendor
  ✓ 400 unknown item
  ✓ 400 auto-detected item
  ✓ 200 valid tick — flag + timestamp set
  ✓ 200 idempotent — timestamp preserved on second tick

checkProfileCompleteness helper:
  ✓ false on description too short
  ✓ false on no specialism source
  ✓ false on missing company
  ✓ true via practiceAreas
  ✓ true via industrySpecialisms (when practiceAreas absent)
  ✓ true via businessProfile.specializations (when both arrays absent)

Post-generate auto-detection:
  ✓ flags firstPillarPostGenerated when pillar in body
  ✓ does NOT flag firstPrimaryDataAdded on whitespace-only primaryData
  ✓ flags firstPrimaryDataAdded on non-empty primaryData
  ✓ idempotent — already-true flag keeps original timestamp

Sanity:
  ✓ ONBOARDING_TICKABLE_ITEMS (3) + ONBOARDING_AUTO_DETECTED_ITEMS (4) disjoint
```

Mocks: Anthropic SDK via `vi.mock` (no live LLM calls), Vendor static methods + `Vendor.prototype.save` via `vi.spyOn` (no live DB). Real JWT signed with throwaway secret so `vendorAuth` runs unchanged.

Full suite (`npx vitest run`): 62/62 running tests pass. The pre-existing `quoteAcceptanceLogic.test.js` import-error file is unchanged — already tracked in `docs/tech-debt.md`.

## Decisions / divergences from the spec (flagged, not hidden)

1. **Coexistence with `account.onboardingCompleted`.** The Vendor schema already had a coarse `account.onboardingCompleted: Boolean` field set by `POST /onboarding-complete`. Spec didn't mention it. Left untouched — the new `onboardingChecklist` is granular, the old field is binary. Both stay; no removal/migration.

2. **`PUT /profile` not `PUT /:vendorId`.** The spec referenced `PUT /api/vendors/:vendorId` but the actual canonical profile-update endpoint is `PUT /api/vendors/profile` (vendor identified via JWT, not URL param). Auto-detection wired into the real endpoint.

3. **Two product-creation paths, both wired.** Spec hedged ("`vendorProductRoutes.js` or `vendorServiceRoutes.js`"). The legacy `POST /products` lives inside `vendorUploadRoutes.js` (1860 lines), and the schema-first `POST /` lives in `vendorServiceRoutes.js`. `routes/vendorProductRoutes.js` itself is a 9-line listing-only stub. Wired detection in BOTH live creation paths so vendors using either flip the same flag.

4. **`{ _id: false }` on the subdocument.** Spec wrote `_id: false` as a sibling of `type:` on the new field. That's not the standard Mongoose pattern — used `new mongoose.Schema({...}, { _id: false })` for the inner schema instead. Same effect; cleaner.

5. **Post-generate idempotency uses query-filtered atomic writes**, not a read-then-write. The spec's pseudocode implied checking `vendor.onboardingChecklist.firstPillarPostGenerated` before save — but the existing handler's `.select()` doesn't include `onboardingChecklist`. Rather than expand the select clause and risk impacting the generator, each flag write is a single atomic `updateOne` with a `$or: [{$ne: true}, {$exists: false}]` filter. If the flag is already true the write is a no-op and the timestamp is preserved. Verified by test.

## Out of scope (per spec §8)

- Frontend changes (separate PR after this merges)
- Admin reset for a vendor's checklist
- Email / notification triggers on completion
- Backfilling existing vendors (defaults handle it — they appear as 0/7 until events fire)
- Wiring `checkProfileCompleteness` against existing vendors (only triggers on next profile update)
- Adding more checklist items / changing names

---
_Generated by [Claude Code](https://claude.ai/code/session_01C29TaEAexvYV1nDN3EUHeq)_