### PR TITLE
fix(copy): soften 90-day guarantee backend emails

### DIFF
--- a/routes/stripeRoutes.js
+++ b/routes/stripeRoutes.js
@@ -491,7 +491,7 @@ async function handleCheckoutComplete(session) {
               </table>
               <div style="background: #f5f3ff; border-radius: 8px; padding: 16px; margin: 16px 0;">
                 <p style="color: #374151; margin: 0; font-size: 14px;">
-                  <strong>90-day guarantee:</strong> If your AI Visibility Score doesn't improve within 90 days, we'll refund you in full.
+                  <strong>90-day promise</strong> &mdash; if your AI Visibility Score isn't moving in the right direction within 90 days of schema install, we'll review your account and process a full refund.
                 </p>
               </div>
               <a href="${dashboardUrl}" style="display: inline-block; background: #7c3aed; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin-top: 8px;">Go to Dashboard</a>
@@ -500,7 +500,7 @@ async function handleCheckoutComplete(session) {
               </p>
             </div>
           `,
-          text: `Welcome to TendorAI Pro! Payment of £299/month confirmed. Step 1: Complete your profile at ${dashboardUrl}/settings. Step 2: Reply with your website login — schema installed within 48hrs. Step 3: First AI Visibility Report arrives Monday. 90-day guarantee — score improves or full refund. Questions? hello@tendorai.com`,
+          text: `Welcome to TendorAI Pro! Payment of £299/month confirmed. Step 1: Complete your profile at ${dashboardUrl}/settings. Step 2: Reply with your website login — schema installed within 48hrs. Step 3: First AI Visibility Report arrives Monday. 90-day promise — review and refund if your score isn't moving in the right direction. Questions? hello@tendorai.com`,
           from: 'TendorAI <hello@tendorai.com>',
         });
         logger.info('Pro upgrade email sent', { vendorId: vendor._id, email: vendor.email });


### PR DESCRIPTION
Backend mirror of the frontend copy fix that just shipped. Replaces the hard-promise wording ("90-day guarantee", "score improves or full refund") in the Pro-upgrade welcome email with the softer "90-day promise" framing that matches the frontend sales page.

Two edits in one file (`routes/stripeRoutes.js`). No tests reference the old wording. No model, route, or schema changes.

## Why

PR #38 (feature audit) flagged that the literal copy commits to a quantitative refund rule the backend has no machinery to verify. The frontend copy was softened in a separate pass; the welcome email and SMS-style fallback still carried the harder wording. This brings the email pair into alignment.

## Files changed

| File | Δ |
|---|---|
| `routes/stripeRoutes.js` | +2 / −2 |

## Before / after

**Long-form HTML email body — `routes/stripeRoutes.js:494`**

Before:
```html
<strong>90-day guarantee:</strong> If your AI Visibility Score doesn't improve within 90 days, we'll refund you in full.
```

After:
```html
<strong>90-day promise</strong> &mdash; if your AI Visibility Score isn't moving in the right direction within 90 days of schema install, we'll review your account and process a full refund.
```

Notes:
- Kept `<strong>` around "90-day promise" so the email retains the visual emphasis the old `<strong>90-day guarantee:</strong>` lead-in provided. Wording after the dash is verbatim from the spec.
- Used `&mdash;` to match the surrounding HTML email's existing dash convention (lines 476, 482, 488 in the same template all use `&mdash;`).

**Plain-text fallback / SMS-style variant — `routes/stripeRoutes.js:503`**

Before (substring of the `text:` template literal):
```
90-day guarantee — score improves or full refund.
```

After:
```
90-day promise — review and refund if your score isn't moving in the right direction.
```

Verbatim from spec. Literal em-dash kept because the rest of the plain-text variant uses literal em-dashes.

## Repo-wide sweep

Searched for the four target phrases across the whole codebase (`*.js`, `*.mjs`, `*.html`, `*.json`, excluding `node_modules`):

- `"90-day guarantee"` — was 2 hits, now 0
- `"score improves or full refund"` — was 1 hit, now 0
- `"10 points within 90 days"` — was 0 hits (not in the email copy as the spec assumed; that wording lived only on the sales sheet, which the frontend pass handled separately)
- `"improve by at least 10 points"` — was 0 hits

Specifically checked for stragglers in:
- `services/emailService.js` — no match
- `services/emailTemplates.js` — no match
- `routes/` — only `stripeRoutes.js`
- All other email-sending paths (`sendVendorWelcomeEmail`, `sendAeoReportEmail`, `sendSchemaInstallAdminNotification`, `sendSchemaInstallCompleteNotification`, etc.) — none carry guarantee wording

## Tests

No tests reference the old wording (`grep` of `tests/` and `test/` returned zero hits). No vitest snapshot files exist. Per spec, no new tests added for this copy change.

## Out of scope

- Frontend copy on the sales page (handled in the parallel frontend PR).
- Building the actual 90-day eligibility tracking machinery (logged as Priority 2 in PR #38's audit; tracked separately).

References:
- PR #38 (`docs: feature audit 2026-04-25`) — Item 4 verdict and recommended copy change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C29TaEAexvYV1nDN3EUHeq)_