### PR TITLE
feat(health): add unauthenticated GET /health for keep-warm probes

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,19 @@ const app = express();
 // Trust proxy for Render
 app.set('trust proxy', 1);
 
+// ─── Health check ─────────────────────────────────────────────────────
+// Mounted before every other middleware so a keep-warm probe can
+// reach it even if a downstream middleware misbehaves. No auth, no
+// rate limit, no body parser dependency. Shape is intentionally tiny
+// to keep the keep-warm payload cheap.
+app.get('/health', (_req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptimeSeconds: Math.round(process.uptime()),
+  });
+});
+
 // ========================================
 // ALLOWED ORIGINS (single source of truth)
 // ========================================


### PR DESCRIPTION
Adds an unauthenticated `GET /health` to the Express backend so the keep-warm service can ping it without auth.

## Why

Render free / starter dynos sleep on idle. The keep-warm pinger needs an endpoint that:
- Doesn't require auth (so no JWT bookkeeping for the pinger)
- Sits ahead of any middleware that could misbehave (so `/health` answers even when downstream is degraded)
- Returns cheaply (so the keep-warm payload stays small)

## What

One change in `index.js` — 13 lines added. The handler is mounted at line 60-72, immediately after `const app = express()` (line 55) and **before** helmet, CORS, rate limiting, mongoSanitize, xss, body parsers, logging, and every router mount.

```js
app.get('/health', (_req, res) => {
  res.status(200).json({
    status: 'ok',
    timestamp: new Date().toISOString(),
    uptimeSeconds: Math.round(process.uptime()),
  });
});
```

## Behaviour

- **Auth:** none.
- **Rate limit:** none. The existing `app.use('/api/', generalLimiter)` (line 146) only applies to `/api/*` paths, so `/health` is naturally outside it.
- **CORS:** the handler is mounted *before* `app.use(cors(...))`, so the keep-warm probe doesn't need an origin header. (CORS is a browser concept — server-to-server pings don't need it.)
- **Body parser:** GET, no body, no parser dependency.

## Response shape

```json
{
  "status": "ok",
  "timestamp": "2026-04-27T09:45:50.734Z",
  "uptimeSeconds": 3
}
```

`uptimeSeconds` is `process.uptime()` rounded — useful for spotting unexpected restarts in keep-warm logs.

## Verification

In-process probe spun up an Express app with the same handler shape and hit `GET /health`:

```
status: 200
content-type: application/json; charset=utf-8
body: {"status":"ok","timestamp":"2026-04-27T09:45:50.734Z","uptimeSeconds":3}
```

200 confirmed locally. **Cannot confirm post-deploy from this sandbox** — once merged and Render auto-deploys from `main`, hit `https://api.tendorai.com/health` (or whatever the prod hostname is) to verify.

## Existing `/health`-named endpoints (untouched)

Two router-internal probes already exist; both stay where they are:

- `routes/aiRoutes.js:280` → `GET /api/ai/health` — AI subsystem probe
- `routes/vendorListings.js:276` → `GET /recommend/health` — recommendation subsystem probe

The new top-level `/health` is the canonical keep-warm target and doesn't interfere with either.

## Out of scope

- Liveness vs readiness split (e.g. checking Mongo connection, Stripe, Resend). Could be a follow-up if the keep-warm tool needs a separate `/ready` endpoint.
- Adding `/health` to the rate limit's bypass list — not needed, already outside `/api/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C29TaEAexvYV1nDN3EUHeq)_