### PR TITLE
fix(approvals): persist liveUrl on approval doc + surface in list end…

### DIFF
--- a/models/ApprovalQueue.js
+++ b/models/ApprovalQueue.js
@@ -47,6 +47,7 @@ const approvalQueueSchema = new mongoose.Schema({
   executedAt: { type: Date },
   executionResult: { type: mongoose.Schema.Types.Mixed },
   executionError: { type: String },
+  liveUrl: { type: String, default: null },
   source: { type: String },
 });
 

--- a/routes/adminApprovalRoutes.js
+++ b/routes/adminApprovalRoutes.js
@@ -78,6 +78,8 @@ router.post('/:id/execute', async (req, res) => {
     let liveUrl = null;
     if (item.itemType === 'content_draft' && item.executionResult?.slug) {
       liveUrl = `https://tendorai.com/resources/${item.executionResult.slug}`;
+      item.liveUrl = liveUrl;
+      await item.save();
       pingBingIndexNow([liveUrl]).then(result => {
         if (result.ok) console.log(`[IndexNow] Pinged for ${liveUrl}`);
       });

--- a/scripts/backfillApprovalLiveUrl.js
+++ b/scripts/backfillApprovalLiveUrl.js
@@ -1,0 +1,36 @@
+import mongoose from 'mongoose';
+import ApprovalQueue from '../models/ApprovalQueue.js';
+
+async function main() {
+  console.log('Connecting to MongoDB...');
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log('Connected.\n');
+
+  const items = await ApprovalQueue.find({
+    itemType: 'content_draft',
+    status: 'executed',
+    liveUrl: { $in: [null, undefined, ''] },
+    'executionResult.slug': { $exists: true },
+  });
+
+  console.log(`Found ${items.length} executed content_draft items without liveUrl.\n`);
+
+  let updated = 0;
+  for (const item of items) {
+    const slug = item.executionResult?.slug;
+    if (!slug) continue;
+
+    item.liveUrl = `https://tendorai.com/resources/${slug}`;
+    await item.save();
+    console.log(`  Updated ${item._id}: ${item.liveUrl}`);
+    updated++;
+  }
+
+  console.log(`\nDone. Updated ${updated} of ${items.length} items.`);
+  await mongoose.disconnect();
+}
+
+main().catch(err => {
+  console.error('BACKFILL ERROR:', err);
+  process.exit(1);
+});

--- a/tests/unit/approvalLiveUrl.test.js
+++ b/tests/unit/approvalLiveUrl.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+// Use real ApprovalQueue model for schema validation
+const { default: ApprovalQueue } = await import('../../models/ApprovalQueue.js');
+
+describe('ApprovalQueue liveUrl field', () => {
+  it('schema includes liveUrl field with default null', () => {
+    const paths = ApprovalQueue.schema.paths;
+    expect(paths.liveUrl).toBeDefined();
+    expect(paths.liveUrl.instance).toBe('String');
+    expect(paths.liveUrl.defaultValue).toBeNull();
+  });
+
+  it('liveUrl can be set on a document', () => {
+    const doc = new ApprovalQueue({
+      vendorId: new mongoose.Types.ObjectId(),
+      agentName: 'writer',
+      itemType: 'content_draft',
+      title: 'Test',
+      draftPayload: { title: 'Test', body: 'Body' },
+      status: 'executed',
+      liveUrl: 'https://tendorai.com/resources/test-slug-abc123',
+    });
+    expect(doc.liveUrl).toBe('https://tendorai.com/resources/test-slug-abc123');
+  });
+
+  it('liveUrl defaults to null when not set', () => {
+    const doc = new ApprovalQueue({
+      vendorId: new mongoose.Types.ObjectId(),
+      agentName: 'writer',
+      itemType: 'content_draft',
+      title: 'Test',
+      draftPayload: { title: 'Test', body: 'Body' },
+    });
+    expect(doc.liveUrl).toBeNull();
+  });
+
+  it('liveUrl is included in toJSON output', () => {
+    const doc = new ApprovalQueue({
+      vendorId: new mongoose.Types.ObjectId(),
+      agentName: 'writer',
+      itemType: 'content_draft',
+      title: 'Test',
+      draftPayload: { title: 'Test', body: 'Body' },
+      liveUrl: 'https://tendorai.com/resources/my-post-abc123',
+    });
+    const json = doc.toJSON();
+    expect(json.liveUrl).toBe('https://tendorai.com/resources/my-post-abc123');
+  });
+});


### PR DESCRIPTION
…point

- models/ApprovalQueue.js: added liveUrl field (String, default null)
- routes/adminApprovalRoutes.js: execute handler now persists liveUrl to the document via item.save() before responding, so it appears in subsequent list queries
- scripts/backfillApprovalLiveUrl.js: one-off migration for existing executed content_draft items that have a slug in executionResult but no liveUrl set yet. Run with: node scripts/backfillApprovalLiveUrl.js
- tests/unit/approvalLiveUrl.test.js: 4 tests confirming schema, defaults, and serialisation

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN