### PR TITLE
feat: weekly Pro digest email — replace AEO re-generation with struct…

### DIFF
--- a/jobs/scheduledReports.js
+++ b/jobs/scheduledReports.js
@@ -85,34 +85,8 @@ function deriveCategory(vendor) {
   return vendorType;
 }
 
-/**
- * Send the report notification email via Resend.
- */
-async function sendReportEmail(vendor, reportUrl, periodLabel) {
-  await sendEmail({
-    to: vendor.email,
-    subject: `Your AI Visibility Report for ${periodLabel} is ready`,
-    html: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #1a1a2e;">Hi ${vendor.name || vendor.company},</h2>
-        <p>Your latest AI Visibility (AEO) Report is ready.</p>
-        <p>
-          <a href="${reportUrl}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">
-            View Your Report
-          </a>
-        </p>
-        <p style="color: #666; font-size: 14px;">
-          This report shows how visible your business is to AI assistants like ChatGPT, Claude, and Perplexity,
-          and what you can do to improve your ranking.
-        </p>
-        <p style="color: #999; font-size: 12px;">
-          You're receiving this because you have an active ${PRO_TIER_VALUES.includes(vendor.tier) || PRO_ACCOUNT_TIERS.includes(vendor.account?.tier) ? 'Pro' : 'Starter'} subscription on TendorAI.
-        </p>
-      </div>
-    `,
-    text: `Hi ${vendor.name || vendor.company}, your latest AI Visibility Report for ${periodLabel} is ready. View it here: ${reportUrl}`,
-  });
-}
+// sendReportEmail removed — replaced by weeklyProDigestTemplate for Pro vendors.
+// Starter monthly cron still uses generateVendorReports() which sends its own email inline.
 
 /**
  * Sleep helper for rate limiting between vendors.
@@ -128,6 +102,8 @@ const STARTER_TIER_VALUES = ['starter', 'basic', 'visible'];
 const STARTER_ACCOUNT_TIERS = ['silver', 'bronze', 'starter'];
 
 /**
+ * @deprecated For Pro vendors, use the weekly digest cron at 08:00 UTC instead.
+ * This function is retained for the Starter monthly cron ('0 6 1 * *') only.
  * Generate AEO reports for all vendors on a given tier.
  */
 export async function generateVendorReports(tier) {
@@ -205,10 +181,14 @@ export async function generateVendorReports(tier) {
 
       const reportUrl = `${frontendUrl}/aeo-report/results/${report._id}`;
 
-      // Send email notification via Resend
       if (vendor.email) {
         try {
-          await sendReportEmail(vendor, reportUrl, periodLabel);
+          await sendEmail({
+            to: vendor.email,
+            subject: `Your AI Visibility Report for ${periodLabel} is ready`,
+            html: `<div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;"><h2>Hi ${vendor.company},</h2><p>Your latest AI Visibility Report is ready.</p><p><a href="${reportUrl}" style="display:inline-block;padding:12px 24px;background:#6366f1;color:white;text-decoration:none;border-radius:6px;font-weight:bold;">View Your Report</a></p></div>`,
+            text: `Hi ${vendor.company}, your AI Visibility Report for ${periodLabel} is ready: ${reportUrl}`,
+          });
           logger.info(`[ScheduledReports] Sent report email to ${vendor.email} for ${vendor.company}`);
         } catch (emailErr) {
           logger.error(`[ScheduledReports] Email failed for ${vendor.company}:`, emailErr.message);
@@ -357,10 +337,73 @@ export function startScheduledReports() {
     generateVendorReports('starter');
   });
 
-  // Pro: every Monday at 6am UTC
-  cron.schedule('0 6 * * 1', () => {
-    logger.info('[ScheduledReports] Triggering weekly Pro reports...');
-    generateVendorReports('pro');
+  // Pro weekly digest: every Monday at 08:00 UTC (09:00 BST)
+  // Replaced the old generateVendorReports('pro') AEO re-generation cron.
+  // Sends a structured digest email with score delta, agent activity, and citations.
+  cron.schedule('0 8 * * 1', async () => {
+    logger.info('[ScheduledReports] Triggering weekly Pro digest emails...');
+    try {
+      const { buildWeeklyProDigestForAllVendors } = await import('../services/weeklyProDigest.js');
+      const { weeklyProDigestTemplate, weeklyProDigestSubject } = await import('../services/emailTemplates.js');
+
+      const results = await buildWeeklyProDigestForAllVendors();
+      let sent = 0;
+      let skipped = 0;
+      let failed = 0;
+
+      for (const { vendorId, email, digest, error } of results) {
+        if (error || !digest) {
+          logger.error(`[WeeklyDigest] Build failed for vendor ${vendorId}: ${error}`);
+          failed++;
+          continue;
+        }
+        if (!email || email.includes('@placeholder.tendorai.com')) {
+          logger.info(`[WeeklyDigest] Skipping vendor ${vendorId}: no valid email`);
+          skipped++;
+          continue;
+        }
+
+        try {
+          const html = weeklyProDigestTemplate(digest);
+          const subject = weeklyProDigestSubject(digest);
+          await sendEmail({
+            to: email,
+            subject,
+            html,
+            text: `Hi ${digest.vendor.firstName || 'there'}, your weekly TendorAI report is ready. Score: ${digest.score.current ?? 'calculating'}. View: https://www.tendorai.com/vendor-dashboard`,
+          });
+
+          try {
+            await AgentRun.create({
+              vendorId,
+              agentName: 'reporter',
+              weekStarting: digest.weekStarting,
+              status: 'completed',
+              startedAt: new Date(),
+              completedAt: new Date(),
+              durationMs: 0,
+              summary: `Weekly digest email sent to ${email}. Score: ${digest.score.current ?? 'N/A'}.`,
+              artifacts: {
+                digestSent: true,
+                score: digest.score.current,
+                weekStarting: digest.weekStarting,
+              },
+            });
+          } catch (runErr) {
+            logger.error(`[WeeklyDigest] AgentRun write failed for ${vendorId}: ${runErr.message}`);
+          }
+
+          sent++;
+        } catch (emailErr) {
+          logger.error(`[WeeklyDigest] Email send failed for ${vendorId}: ${emailErr.message}`);
+          failed++;
+        }
+      }
+
+      logger.info(`[WeeklyDigest] Complete: ${sent} sent, ${skipped} skipped, ${failed} failed`);
+    } catch (err) {
+      logger.error('[WeeklyDigest] Cron run failed:', err.message);
+    }
   });
 
   // Past-due subscription downgrade: daily at 9am UTC
@@ -372,8 +415,8 @@ export function startScheduledReports() {
   logger.info('[ScheduledReports] Cron jobs registered:');
   logger.info('  - AI mentions (weekly): every Sunday at 03:00 UTC');
   logger.info('  - Writer Agent (weekly): every Monday at 05:00 UTC');
-  logger.info('  - Pro (monthly): 1st of every month at 06:00 UTC');
-  logger.info('  - Pro (weekly): every Monday at 06:00 UTC');
+  logger.info('  - Starter reports (monthly): 1st of every month at 06:00 UTC');
+  logger.info('  - Pro weekly digest (weekly): every Monday at 08:00 UTC');
   logger.info('  - Past_due downgrade (daily): every day at 09:00 UTC');
 
   // Writer Agent cron — runs Monday 05:00 UTC, before weekly reports at 06:00

--- a/services/emailTemplates.js
+++ b/services/emailTemplates.js
@@ -587,6 +587,169 @@ export const newLeadNotificationTemplate = ({ vendorName, service, postcode, req
 `);
 };
 
+// =====================================================
+// WEEKLY PRO DIGEST
+// =====================================================
+
+export const weeklyProDigestTemplate = (digest) => {
+  const { vendor, weekStarting, weekEnding, score, citations, agentActivity, needsAttention } = digest;
+
+  const firstName = vendor.firstName || 'there';
+  const firmName = vendor.firmName || 'your firm';
+
+  const startDay = new Date(weekStarting).getUTCDate();
+  const endDate = new Date(weekEnding);
+  const endDay = endDate.getUTCDate();
+  const monthName = endDate.toLocaleString('en-GB', { month: 'long', timeZone: 'UTC' });
+  const year = endDate.getUTCFullYear();
+  const dateRange = `${startDay}–${endDay} ${monthName} ${year}`;
+
+  const scoreDisplay = score.current != null ? `${score.current}/100` : 'being calculated';
+  let deltaDisplay = '';
+  if (score.delta != null && score.delta !== 0) {
+    const sign = score.delta > 0 ? '+' : '';
+    deltaDisplay = ` (${sign}${score.delta} from last week)`;
+  }
+
+  const platformsWithCitations = Object.values(citations.byPlatform).filter(p => p.mentioned > 0).length;
+
+  let citationLine;
+  if (citations.total === 0) {
+    citationLine = 'No citations captured this week — Detective is investigating why';
+  } else {
+    citationLine = `${citations.total} AI citation${citations.total !== 1 ? 's' : ''} captured across ${platformsWithCitations} platform${platformsWithCitations !== 1 ? 's' : ''}`;
+  }
+
+  const agentActions =
+    (agentActivity.writer.draftsProduced || 0) +
+    (agentActivity.listings.submitted || 0) +
+    (agentActivity.reviews.sent || 0) +
+    (agentActivity.detective.findingsCount || 0) +
+    (agentActivity.reconnaissance.queriesScanned || 0);
+
+  const isNewVendor = (() => {
+    const now = new Date();
+    const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    return score.current == null && agentActions === 0 && citations.total === 0;
+  })();
+
+  const topFinding = agentActivity.detective.topFinding;
+
+  let needsAttentionHtml = '';
+  if (needsAttention.length > 0) {
+    const items = needsAttention.slice(0, 5).map(item =>
+      `<li style="padding:3px 0;color:#374151;font-size:14px;line-height:1.5;">${item.title}</li>`
+    ).join('');
+    needsAttentionHtml = `
+              <div style="margin:24px 0 0;">
+                <p style="color:#1A56A0;font-size:15px;font-weight:600;margin:0 0 8px;">Items needing your input (${needsAttention.length}):</p>
+                <ul style="margin:0 0 8px;padding-left:24px;">${items}</ul>
+                <p style="margin:0;"><a href="https://www.tendorai.com/vendor-dashboard/approvals" style="color:#1A56A0;font-size:14px;text-decoration:none;">Review in dashboard &rarr;</a></p>
+              </div>`;
+  }
+
+  let topFindingHtml = '';
+  if (topFinding) {
+    topFindingHtml = `
+              <div style="background:#f0f4f8;border-left:4px solid #1A56A0;border-radius:0 6px 6px 0;padding:14px 18px;margin:24px 0 0;">
+                <p style="color:#1A56A0;font-size:14px;font-weight:600;margin:0 0 4px;">Top diagnosis this week</p>
+                <p style="color:#374151;font-size:14px;line-height:1.5;margin:0 0 6px;"><strong>${topFinding.title}</strong></p>
+                <p style="color:#374151;font-size:14px;line-height:1.5;margin:0;">${topFinding.recommendation}</p>
+              </div>`;
+  }
+
+  let mainContent;
+  if (isNewVendor) {
+    mainContent = `
+              <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 24px;">Setting up your TendorAI account this week — full report next Monday.</p>`;
+  } else {
+    mainContent = `
+              <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 8px;font-weight:600;">This week:</p>
+              <ul style="margin:0 0 24px;padding-left:24px;">
+                <li style="padding:3px 0;color:#374151;font-size:14px;line-height:1.5;">AI Visibility Score: <strong>${scoreDisplay}</strong>${deltaDisplay}</li>
+                <li style="padding:3px 0;color:#374151;font-size:14px;line-height:1.5;">${citationLine}</li>
+                <li style="padding:3px 0;color:#374151;font-size:14px;line-height:1.5;">${agentActions} action${agentActions !== 1 ? 's' : ''} completed by your TendorAI agents</li>
+              </ul>`;
+  }
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your TendorAI week — ${firmName}</title>
+  <!--[if mso]><noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript><![endif]-->
+</head>
+<body style="margin:0;padding:0;background-color:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">Score: ${scoreDisplay}${deltaDisplay} | ${citationLine}</div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6;padding:24px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.08);">
+
+          <tr>
+            <td style="background:#ffffff;padding:24px 40px 16px;text-align:center;border-bottom:1px solid #e5e7eb;">
+              <img src="https://www.tendorai.com/logo.png" alt="TendorAI" width="140" style="display:inline-block;max-width:140px;height:auto;" />
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:32px 40px;">
+
+              <p style="color:#374151;font-size:16px;line-height:1.7;margin:0 0 4px;">Hi ${firstName},</p>
+              <p style="color:#374151;font-size:15px;line-height:1.7;margin:0 0 20px;">Your weekly TendorAI report is ready.</p>
+
+              ${mainContent}
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding:0 0 24px;">
+                    <a href="https://www.tendorai.com/vendor-dashboard" style="display:inline-block;background:#1A56A0;color:#ffffff;padding:14px 32px;text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;">View Full Report &rarr;</a>
+                  </td>
+                </tr>
+              </table>
+
+              ${needsAttentionHtml}
+              ${topFindingHtml}
+
+              <div style="padding-top:24px;border-top:1px solid #e5e7eb;margin-top:24px;">
+                <p style="color:#374151;font-size:14px;line-height:1.6;margin:0 0 4px;">— Scott</p>
+                <p style="color:#6b7280;font-size:13px;line-height:1.4;margin:0;">TendorAI</p>
+              </div>
+
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background:#f9fafb;padding:20px 40px;text-align:center;border-top:1px solid #e5e7eb;">
+              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">
+                <a href="https://www.tendorai.com/vendor-dashboard/settings" style="color:#6b7280;text-decoration:none;">Manage email preferences</a>
+                &nbsp;&middot;&nbsp;
+                <a href="https://www.tendorai.com/unsubscribe" style="color:#6b7280;text-decoration:none;">Unsubscribe</a>
+              </p>
+              <p style="margin:8px 0 0;color:#9ca3af;font-size:11px;">Sent every Monday morning to ${vendor.id ? 'your account email' : 'you'}.</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+};
+
+export function weeklyProDigestSubject(digest) {
+  const firmName = digest.vendor.firmName || 'your firm';
+  const endDate = new Date(digest.weekEnding);
+  const startDay = new Date(digest.weekStarting).getUTCDate();
+  const endDay = endDate.getUTCDate();
+  const monthName = endDate.toLocaleString('en-GB', { month: 'short', timeZone: 'UTC' });
+  const year = endDate.getUTCFullYear();
+  return `Your TendorAI week — ${firmName}, ${startDay}–${endDay} ${monthName} ${year}`;
+}
+
 // Export all templates
 export default {
   passwordResetTemplate,
@@ -598,5 +761,7 @@ export default {
   reviewRequestTemplate,
   verifiedReviewNotificationTemplate,
   aeoReportTemplate,
-  newLeadNotificationTemplate
+  newLeadNotificationTemplate,
+  weeklyProDigestTemplate,
+  weeklyProDigestSubject,
 };

--- a/services/weeklyProDigest.js
+++ b/services/weeklyProDigest.js
@@ -1,0 +1,301 @@
+import Vendor from '../models/Vendor.js';
+import AeoReport from '../models/AeoReport.js';
+import AIMentionScan from '../models/AIMentionScan.js';
+import AgentRun from '../models/AgentRun.js';
+import DirectoryListing from '../models/DirectoryListing.js';
+import ApprovalQueue from '../models/ApprovalQueue.js';
+
+const PRO_TIERS = ['pro', 'managed', 'verified', 'enterprise'];
+const PRO_ACCOUNT_TIERS = ['gold', 'platinum', 'pro', 'verified'];
+
+function weekEnd(weekStarting) {
+  const end = new Date(weekStarting);
+  end.setUTCDate(end.getUTCDate() + 6);
+  end.setUTCHours(23, 59, 59, 999);
+  return end;
+}
+
+function previousWeekStart(weekStarting) {
+  const prev = new Date(weekStarting);
+  prev.setUTCDate(prev.getUTCDate() - 7);
+  return prev;
+}
+
+function parseFirstName(vendor) {
+  const raw = vendor.name || vendor.contactInfo?.name || null;
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed || /^(admin|reception|info|office|accounts|enquiries)/i.test(trimmed)) return null;
+  return trimmed.split(/\s+/)[0];
+}
+
+async function buildScoreSection(vendorId, weekStarting) {
+  try {
+    const reports = await AeoReport.find({ vendorId })
+      .sort({ createdAt: -1 })
+      .select('score createdAt')
+      .limit(50)
+      .lean();
+
+    if (!reports.length) {
+      return { current: null, previous: null, delta: null, history: [] };
+    }
+
+    const byWeek = new Map();
+    for (const r of reports) {
+      if (r.score == null) continue;
+      const ws = AgentRun.normaliseWeekStarting(r.createdAt).toISOString();
+      if (!byWeek.has(ws)) byWeek.set(ws, { date: r.createdAt, score: r.score });
+    }
+
+    const thisWeekKey = weekStarting.toISOString();
+    const prevWeekKey = previousWeekStart(weekStarting).toISOString();
+
+    const current = byWeek.get(thisWeekKey)?.score ?? null;
+    const previous = byWeek.get(prevWeekKey)?.score ?? null;
+    const delta = (current != null && previous != null) ? current - previous : null;
+
+    const history = [...byWeek.values()]
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+      .slice(-12)
+      .map(h => ({ date: h.date, score: h.score }));
+
+    return { current, previous, delta, history };
+  } catch {
+    return { current: null, previous: null, delta: null, history: [] };
+  }
+}
+
+async function buildCitationsSection(vendorId, weekStarting, ending) {
+  try {
+    const scans = await AIMentionScan.find({
+      vendorId,
+      scanDate: { $gte: weekStarting, $lte: ending },
+    }).lean();
+
+    const platforms = ['chatgpt', 'perplexity', 'claude', 'gemini', 'grok', 'metaai'];
+    const byPlatform = {};
+    for (const p of platforms) {
+      const key = p === 'metaai' ? 'meta_ai' : p;
+      const platformScans = scans.filter(s => s.platform === p);
+      const mentioned = platformScans.filter(s => s.mentioned).length;
+      byPlatform[key] = { mentioned, target: platformScans.length, change: 0 };
+    }
+
+    const total = scans.filter(s => s.mentioned).length;
+
+    const captured = scans
+      .filter(s => s.mentioned)
+      .map(s => ({
+        platform: s.platform === 'metaai' ? 'meta_ai' : s.platform,
+        query: s.prompt || '',
+        position: s.position || 'mentioned',
+        snippet: s.responseSnippet || null,
+        capturedAt: s.scanDate,
+      }));
+
+    return { total, byPlatform, captured };
+  } catch {
+    return {
+      total: 0,
+      byPlatform: {
+        chatgpt: { mentioned: 0, target: 0, change: 0 },
+        perplexity: { mentioned: 0, target: 0, change: 0 },
+        claude: { mentioned: 0, target: 0, change: 0 },
+        gemini: { mentioned: 0, target: 0, change: 0 },
+        grok: { mentioned: 0, target: 0, change: 0 },
+        meta_ai: { mentioned: 0, target: 0, change: 0 },
+      },
+      captured: [],
+    };
+  }
+}
+
+async function buildAgentActivity(vendorId, weekStarting) {
+  const result = {
+    writer: { ran: false, draftsProduced: 0, draftTitles: [], pendingApproval: 0 },
+    detective: { ran: false, findingsCount: 0, topFinding: null },
+    listings: { ran: false, submitted: 0, live: 0, pending: 0, directories: [] },
+    reviews: { ran: false, sent: 0, skipped: { optedOut: 0, cooldown: 0, alreadyReviewed: 0 } },
+    reconnaissance: { ran: false, queriesScanned: 0, platformsScanned: 0 },
+  };
+
+  try {
+    const runs = await AgentRun.find({ vendorId, weekStarting }).lean();
+    const runMap = {};
+    for (const r of runs) runMap[r.agentName] = r;
+
+    const writerRun = runMap.writer;
+    if (writerRun && (writerRun.status === 'completed' || writerRun.status === 'partial')) {
+      result.writer.ran = true;
+      result.writer.draftsProduced = writerRun.artifacts?.postsDrafted || 0;
+      if (writerRun.artifacts?.draftTitle) {
+        result.writer.draftTitles = [writerRun.artifacts.draftTitle];
+      }
+    }
+
+    try {
+      result.writer.pendingApproval = await ApprovalQueue.countDocuments({
+        vendorId,
+        status: 'pending',
+      });
+    } catch { /* ignore */ }
+
+    const detectiveRun = runMap.detective;
+    if (detectiveRun && (detectiveRun.status === 'completed' || detectiveRun.status === 'partial')) {
+      result.detective.ran = true;
+      const findings = detectiveRun.artifacts?.findings || [];
+      result.detective.findingsCount = findings.length;
+      if (findings.length > 0) {
+        const top = findings[0];
+        result.detective.topFinding = {
+          type: top.type || '',
+          severity: top.severity || '',
+          title: top.title || '',
+          detail: top.detail || '',
+          recommendation: top.recommendation || '',
+        };
+      }
+    }
+
+    const listingsRun = runMap.listings;
+    if (listingsRun && (listingsRun.status === 'completed' || listingsRun.status === 'partial')) {
+      result.listings.ran = true;
+      result.listings.submitted = listingsRun.artifacts?.submitted || 0;
+    }
+
+    try {
+      const listings = await DirectoryListing.find({ vendorId }).lean();
+      result.listings.live = listings.filter(l => l.status === 'live').length;
+      result.listings.pending = listings.filter(l =>
+        ['queued', 'submitted', 'pending_verification'].includes(l.status)
+      ).length;
+      result.listings.directories = listings.map(l => ({
+        directory: l.directory,
+        status: l.status,
+      }));
+    } catch { /* ignore */ }
+
+    const reviewsRun = runMap.reviews;
+    if (reviewsRun && (reviewsRun.status === 'completed' || reviewsRun.status === 'partial')) {
+      result.reviews.ran = true;
+      result.reviews.sent = reviewsRun.artifacts?.sent || 0;
+      const skipped = reviewsRun.artifacts?.skipped || {};
+      result.reviews.skipped = {
+        optedOut: skipped.optedOut || 0,
+        cooldown: skipped.cooldown || 0,
+        alreadyReviewed: skipped.alreadyReviewed || 0,
+      };
+    }
+
+    const reconRun = runMap.reconnaissance;
+    if (reconRun && (reconRun.status === 'completed' || reconRun.status === 'partial')) {
+      result.reconnaissance.ran = true;
+      result.reconnaissance.queriesScanned = reconRun.artifacts?.queriesScanned || 0;
+      result.reconnaissance.platformsScanned = reconRun.artifacts?.platformsScanned || 0;
+    }
+  } catch { /* ignore — return defaults */ }
+
+  return result;
+}
+
+async function buildNeedsAttention(vendorId) {
+  try {
+    const pending = await ApprovalQueue.find({ vendorId, status: 'pending' })
+      .select('itemType title')
+      .lean();
+
+    return pending.map(item => ({
+      type: item.itemType === 'content_draft' ? 'draft_approval' : item.itemType,
+      title: item.title || 'Pending item',
+      href: '/vendor-dashboard/approvals',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function buildCompetitorMoves(vendorId, weekStarting, ending) {
+  try {
+    const scans = await AIMentionScan.find({
+      vendorId,
+      scanDate: { $gte: weekStarting, $lte: ending },
+      mentioned: false,
+    }).lean();
+
+    const moves = [];
+    for (const scan of scans) {
+      for (const comp of (scan.competitorsMentioned || [])) {
+        moves.push({
+          platform: scan.platform === 'metaai' ? 'meta_ai' : scan.platform,
+          query: scan.prompt || '',
+          competitor: comp,
+          capturedAt: scan.scanDate,
+        });
+      }
+    }
+    return moves;
+  } catch {
+    return [];
+  }
+}
+
+export async function buildWeeklyProDigest(vendorId, weekStarting = null) {
+  const ws = weekStarting
+    ? AgentRun.normaliseWeekStarting(weekStarting)
+    : AgentRun.normaliseWeekStarting(new Date());
+  const ending = weekEnd(ws);
+
+  const vendor = await Vendor.findById(vendorId)
+    .select('_id company name vendorType tier contactInfo')
+    .lean();
+
+  if (!vendor) throw new Error(`Vendor not found: ${vendorId}`);
+
+  const [score, citations, agentActivity, needsAttention, competitorMoves] = await Promise.all([
+    buildScoreSection(vendorId, ws),
+    buildCitationsSection(vendorId, ws, ending),
+    buildAgentActivity(vendorId, ws),
+    buildNeedsAttention(vendorId),
+    buildCompetitorMoves(vendorId, ws, ending),
+  ]);
+
+  return {
+    vendor: {
+      id: String(vendor._id),
+      firmName: vendor.company || 'Unknown Firm',
+      firstName: parseFirstName(vendor),
+      vendorType: vendor.vendorType || 'unknown',
+      tier: vendor.tier || 'free',
+    },
+    weekStarting: ws,
+    weekEnding: ending,
+    score,
+    citations,
+    agentActivity,
+    needsAttention,
+    competitorMoves,
+    nextWeekPlan: null,
+    generatedAt: new Date(),
+  };
+}
+
+export async function buildWeeklyProDigestForAllVendors(weekStarting = null) {
+  const vendors = await Vendor.find({
+    $or: [
+      { tier: { $in: PRO_TIERS } },
+      { 'account.tier': { $in: PRO_ACCOUNT_TIERS } },
+    ],
+  }).select('_id company email').lean();
+
+  const results = [];
+  for (const vendor of vendors) {
+    try {
+      const digest = await buildWeeklyProDigest(vendor._id, weekStarting);
+      results.push({ vendorId: String(vendor._id), email: vendor.email, digest });
+    } catch (err) {
+      results.push({ vendorId: String(vendor._id), email: vendor.email, digest: null, error: err.message });
+    }
+  }
+  return results;
+}

--- a/tests/unit/weeklyProDigest.test.js
+++ b/tests/unit/weeklyProDigest.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+const VENDOR_ID = new mongoose.Types.ObjectId();
+const VENDOR_PRO = {
+  _id: VENDOR_ID,
+  company: 'Harrison & Co Solicitors',
+  name: 'James Harrison',
+  vendorType: 'solicitor',
+  tier: 'managed',
+  contactInfo: { name: 'James Harrison' },
+};
+
+const mockVendorFindById = vi.fn();
+const mockVendorFind = vi.fn();
+const mockAeoReportFind = vi.fn();
+const mockAIMentionScanFind = vi.fn();
+const mockAgentRunFind = vi.fn();
+const mockAgentRunNormalise = vi.fn((d) => {
+  const date = new Date(d);
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() - (day - 1));
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+});
+const mockDirectoryListingFind = vi.fn();
+const mockApprovalQueueFind = vi.fn();
+const mockApprovalQueueCountDocuments = vi.fn();
+
+vi.mock('../../models/Vendor.js', () => ({
+  default: {
+    findById: (...args) => mockVendorFindById(...args),
+    find: (...args) => mockVendorFind(...args),
+  },
+}));
+
+vi.mock('../../models/AeoReport.js', () => ({
+  default: {
+    find: (...args) => mockAeoReportFind(...args),
+  },
+}));
+
+vi.mock('../../models/AIMentionScan.js', () => ({
+  default: {
+    find: (...args) => mockAIMentionScanFind(...args),
+  },
+}));
+
+vi.mock('../../models/AgentRun.js', () => ({
+  default: {
+    find: (...args) => mockAgentRunFind(...args),
+    normaliseWeekStarting: (...args) => mockAgentRunNormalise(...args),
+  },
+}));
+
+vi.mock('../../models/DirectoryListing.js', () => ({
+  default: {
+    find: (...args) => mockDirectoryListingFind(...args),
+  },
+}));
+
+vi.mock('../../models/ApprovalQueue.js', () => ({
+  default: {
+    find: (...args) => mockApprovalQueueFind(...args),
+    countDocuments: (...args) => mockApprovalQueueCountDocuments(...args),
+  },
+}));
+
+const { buildWeeklyProDigest } = await import('../../services/weeklyProDigest.js');
+
+describe('Weekly Pro Digest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockVendorFindById.mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(VENDOR_PRO) }),
+    });
+
+    mockAeoReportFind.mockReturnValue({
+      sort: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+        }),
+      }),
+    });
+
+    mockAIMentionScanFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+    mockAgentRunFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+    mockDirectoryListingFind.mockReturnValue({ lean: vi.fn().mockResolvedValue([]) });
+    mockApprovalQueueFind.mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue([]) }),
+    });
+    mockApprovalQueueCountDocuments.mockResolvedValue(0);
+  });
+
+  it('returns correct output shape with empty data', async () => {
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+
+    expect(result.vendor).toBeDefined();
+    expect(result.vendor.id).toBe(String(VENDOR_ID));
+    expect(result.vendor.firmName).toBe('Harrison & Co Solicitors');
+    expect(result.vendor.firstName).toBe('James');
+    expect(result.vendor.vendorType).toBe('solicitor');
+    expect(result.vendor.tier).toBe('managed');
+
+    expect(result.weekStarting).toBeInstanceOf(Date);
+    expect(result.weekEnding).toBeInstanceOf(Date);
+    expect(result.weekEnding > result.weekStarting).toBe(true);
+
+    expect(result.score).toEqual({
+      current: null,
+      previous: null,
+      delta: null,
+      history: [],
+    });
+
+    expect(result.citations).toBeDefined();
+    expect(result.citations.total).toBe(0);
+    expect(result.citations.byPlatform).toBeDefined();
+    expect(result.citations.byPlatform.chatgpt).toEqual({ mentioned: 0, target: 0, change: 0 });
+    expect(result.citations.byPlatform.meta_ai).toEqual({ mentioned: 0, target: 0, change: 0 });
+    expect(result.citations.captured).toEqual([]);
+
+    expect(result.agentActivity).toBeDefined();
+    expect(result.agentActivity.writer.ran).toBe(false);
+    expect(result.agentActivity.detective.ran).toBe(false);
+    expect(result.agentActivity.listings.ran).toBe(false);
+    expect(result.agentActivity.reviews.ran).toBe(false);
+    expect(result.agentActivity.reconnaissance.ran).toBe(false);
+
+    expect(result.needsAttention).toEqual([]);
+    expect(result.competitorMoves).toEqual([]);
+    expect(result.nextWeekPlan).toBeNull();
+    expect(result.generatedAt).toBeInstanceOf(Date);
+  });
+
+  it('parses firstName correctly', async () => {
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+    expect(result.vendor.firstName).toBe('James');
+  });
+
+  it('returns null firstName for generic contact names', async () => {
+    mockVendorFindById.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({
+          ...VENDOR_PRO,
+          name: 'Admin Team',
+          contactInfo: { name: 'Reception' },
+        }),
+      }),
+    });
+
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+    expect(result.vendor.firstName).toBeNull();
+  });
+
+  it('populates agent activity when runs exist', async () => {
+    const weekStarting = mockAgentRunNormalise(new Date());
+    mockAgentRunFind.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        {
+          agentName: 'writer',
+          weekStarting,
+          status: 'completed',
+          artifacts: { postsDrafted: 1, draftTitle: 'Conveyancing Costs 2026' },
+        },
+        {
+          agentName: 'detective',
+          weekStarting,
+          status: 'completed',
+          artifacts: {
+            findings: [
+              { type: 'platform_silence', severity: 'high', title: 'Not on Perplexity', detail: 'Not mentioned', recommendation: 'Claim profile' },
+            ],
+          },
+        },
+      ]),
+    });
+
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+
+    expect(result.agentActivity.writer.ran).toBe(true);
+    expect(result.agentActivity.writer.draftsProduced).toBe(1);
+    expect(result.agentActivity.writer.draftTitles).toEqual(['Conveyancing Costs 2026']);
+
+    expect(result.agentActivity.detective.ran).toBe(true);
+    expect(result.agentActivity.detective.findingsCount).toBe(1);
+    expect(result.agentActivity.detective.topFinding.title).toBe('Not on Perplexity');
+  });
+
+  it('populates citations when mention scans exist', async () => {
+    mockAIMentionScanFind.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        { platform: 'chatgpt', mentioned: true, position: 'top3', prompt: 'best solicitor Cardiff', responseSnippet: 'Harrison & Co', scanDate: new Date() },
+        { platform: 'perplexity', mentioned: false, position: 'not_mentioned', prompt: 'solicitor Cardiff', competitorsMentioned: ['Rival Law'], scanDate: new Date() },
+      ]),
+    });
+
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+
+    expect(result.citations.total).toBe(1);
+    expect(result.citations.byPlatform.chatgpt.mentioned).toBe(1);
+    expect(result.citations.captured).toHaveLength(1);
+    expect(result.citations.captured[0].platform).toBe('chatgpt');
+  });
+
+  it('populates competitor moves from non-mentioned scans', async () => {
+    mockAIMentionScanFind.mockReturnValue({
+      lean: vi.fn().mockResolvedValue([
+        { platform: 'perplexity', mentioned: false, position: 'not_mentioned', prompt: 'solicitor Cardiff', competitorsMentioned: ['Rival Law', 'Other Firm'], scanDate: new Date() },
+      ]),
+    });
+
+    const result = await buildWeeklyProDigest(VENDOR_ID);
+
+    expect(result.competitorMoves).toHaveLength(2);
+    expect(result.competitorMoves[0].competitor).toBe('Rival Law');
+    expect(result.competitorMoves[0].platform).toBe('perplexity');
+  });
+
+  it('throws for non-existent vendor', async () => {
+    mockVendorFindById.mockReturnValue({
+      select: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(null) }),
+    });
+
+    await expect(buildWeeklyProDigest(new mongoose.Types.ObjectId())).rejects.toThrow('Vendor not found');
+  });
+});


### PR DESCRIPTION
…ured digest

- Add services/weeklyProDigest.js: buildWeeklyProDigest() and buildWeeklyProDigestForAllVendors() producing score delta, citation counts, agent activity summary, needsAttention items, competitor moves per Pro vendor — zero API calls, DB queries only
- Add weeklyProDigestTemplate + weeklyProDigestSubject to services/emailTemplates.js — table-based HTML email with empty-state handling for new vendors, null scores, zero citations
- Replace Pro weekly cron from '0 6 * * 1' (generateVendorReports) to '0 8 * * 1' (digest email) in jobs/scheduledReports.js
- Remove sendReportEmail() inline HTML (broken domain, wrong greeting)
- Inline a minimal email send for Starter monthly cron (unchanged)
- Mark generateVendorReports() as @deprecated (Starter-only)
- Add tests/unit/weeklyProDigest.test.js — 7 smoke tests covering output shape, empty state, agent activity, citations, competitor moves, firstName parsing, vendor-not-found error

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN