### PR TITLE
feat: bump Writer agent cron from weekly to 3x/week (Mon/Wed/Fri)

### DIFF
--- a/jobs/scheduledReports.js
+++ b/jobs/scheduledReports.js
@@ -424,12 +424,12 @@ export function startScheduledReports() {
 
   logger.info('[ScheduledReports] Cron jobs registered:');
   logger.info('  - AI mentions (weekly): every Sunday at 03:00 UTC');
-  logger.info('  - Writer Agent (weekly): every Monday at 05:00 UTC');
+  logger.info('  - Writer Agent (3x weekly): Mon/Wed/Fri at 05:00 UTC');
   logger.info('  - Starter reports (monthly): 1st of every month at 06:00 UTC');
   logger.info('  - Pro weekly digest (weekly): every Monday at 08:00 UTC');
   logger.info('  - Past_due downgrade (daily): every day at 09:00 UTC');
 
-  // Writer Agent cron — runs Monday 05:00 UTC, before weekly reports at 06:00
+  // Writer Agent cron — runs Mon/Wed/Fri 05:00 UTC
   import('./writerAgent.js').then(m => m.registerWriterAgentCron()).catch(err => {
     logger.error('[ScheduledReports] Failed to register Writer Agent cron:', err.message);
   });

--- a/jobs/writerAgent.js
+++ b/jobs/writerAgent.js
@@ -13,7 +13,7 @@ function sleep(ms) {
 
 export async function runWeeklyWriterAgent() {
   const startTime = Date.now();
-  logger.info(`[WriterAgent] Weekly run starting at ${new Date().toISOString()}`);
+  logger.info(`[WriterAgent] Run starting at ${new Date().toISOString()}`);
 
   let vendors;
   try {
@@ -65,7 +65,7 @@ export async function runWeeklyWriterAgent() {
   const durationSec = ((Date.now() - startTime) / 1000).toFixed(1);
 
   const summaryLines = [
-    `Writer Agent weekly run completed in ${durationSec}s`,
+    `Writer Agent run completed in ${durationSec}s`,
     `Total vendors: ${vendors.length}`,
     `Drafted: ${draftedCount}`,
     `Skipped: ${skippedCount}`,
@@ -79,7 +79,7 @@ export async function runWeeklyWriterAgent() {
   try {
     await sendEmail({
       to: ADMIN_EMAIL,
-      subject: `Writer Agent weekly run: ${draftedCount} drafted, ${skippedCount} skipped, ${failedCount} failed`,
+      subject: `Writer Agent run: ${draftedCount} drafted, ${skippedCount} skipped, ${failedCount} failed`,
       text: summaryText,
       html: `<pre style="font-family: monospace; font-size: 14px; line-height: 1.6;">${summaryText}</pre>`,
     });
@@ -91,8 +91,8 @@ export async function runWeeklyWriterAgent() {
 export function registerWriterAgentCron() {
   if (process.env.ENABLE_CRON !== 'true') return;
 
-  cron.schedule('0 5 * * 1', async () => {
-    logger.info('[WriterAgent] Cron trigger: Monday 05:00 UTC');
+  cron.schedule('0 5 * * 1,3,5', async () => {
+    logger.info(`[WriterAgent] Cron trigger: ${new Date().toUTCString()}`);
     try {
       await runWeeklyWriterAgent();
     } catch (err) {
@@ -100,5 +100,5 @@ export function registerWriterAgentCron() {
     }
   });
 
-  logger.info('[WriterAgent] Cron registered: every Monday at 05:00 UTC');
+  logger.info('[WriterAgent] Cron registered: Mon/Wed/Fri at 05:00 UTC');
 }


### PR DESCRIPTION
- Change cron from '0 5 * * 1' to '0 5 * * 1,3,5' in jobs/writerAgent.js
- Update log messages and email subjects to remove "weekly"/"Monday" hardcoding — cron trigger now logs actual UTC date
- Update jobs/scheduledReports.js startup log and comment to reflect Mon/Wed/Fri schedule

No changes to the Writer agent itself, prompt, approval gate, validators, or other agent crons. First 3x run: Wed 13 May 05:00 UTC.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN