### PR TITLE
fix(stripe): redirect Pro signups to /onboarding/firm-facts

### DIFF
--- a/routes/stripeRoutes.js
+++ b/routes/stripeRoutes.js
@@ -192,6 +192,14 @@ router.post('/create-checkout-session', requireStripe, authenticateVendor, async
     }
 
     // Create checkout session
+    // Pro tiers redirect to onboarding form; free/starter land on dashboard.
+    // NOTE: /onboarding/firm-facts does not exist on the frontend yet (Saturday build).
+    // Until it ships, Pro customers hitting this URL will see a 404. No real paying
+    // customers exist currently, so this is acceptable interim state.
+    const isProTier = ['managed', 'verified', 'enterprise'].includes(plan.internalTier);
+    const successPath = isProTier
+      ? '/onboarding/firm-facts?source=stripe&session_id={CHECKOUT_SESSION_ID}'
+      : '/vendor-dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}';
     const session = await stripe.checkout.sessions.create({
       customer: customerId,
       payment_method_types: ['card'],
@@ -202,7 +210,7 @@ router.post('/create-checkout-session', requireStripe, authenticateVendor, async
           quantity: 1,
         },
       ],
-      success_url: `${process.env.FRONTEND_URL || 'https://www.tendorai.com'}/vendor-dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}`,
+      success_url: `${process.env.FRONTEND_URL || 'https://www.tendorai.com'}${successPath}`,
       cancel_url: `${process.env.FRONTEND_URL || 'https://www.tendorai.com'}/vendor-dashboard/upgrade?subscription=cancelled`,
       metadata: {
         vendorId: vendor._id.toString(),


### PR DESCRIPTION
## What this changes

Pro/managed/verified/enterprise customers now land on `/onboarding/firm-facts` after Stripe checkout, where they fill in their firm's operational and branding data before reaching the dashboard.

Free tier signups continue to land on `/vendor-dashboard`.

### Before
```
success_url = /vendor-dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}
```
All tiers → dashboard. Customer pays £299 and sees the regular dashboard with no onboarding prompt.

### After
```javascript
const isProTier = ['managed', 'verified', 'enterprise'].includes(plan.internalTier);
const successPath = isProTier
  ? '/onboarding/firm-facts?source=stripe&session_id={CHECKOUT_SESSION_ID}'
  : '/vendor-dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}';
```
Pro tiers → onboarding form. Free/starter → dashboard (unchanged).

## What's NOT validated yet

- The `/onboarding/firm-facts` route does not exist on the frontend yet — Saturday build. Until it ships, Pro customers hitting this URL will see a 404.
- There are no real paying customers currently, so this is acceptable interim state.
- `cancel_url` unchanged — still goes to `/vendor-dashboard/upgrade?subscription=cancelled`.

## Test status

- 359 passing (unchanged from baseline)
- 12 pre-existing failures (unrelated writerAgent mock chain)
- No tests assert against `success_url` — no breakage

## Linked
- PR #52: FirmFacts model
- PR #53: unified branding + operational schemas

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_