### PR TITLE
fix(firmfacts): accept flat fieldName envelope in PUT handler — Block 1 was silently no-op'ing

### DIFF
--- a/models/FirmFacts.js
+++ b/models/FirmFacts.js
@@ -327,5 +327,22 @@ firmFactsSchema.statics.findOrCreateForVendor = async function (vendorId) {
   return doc;
 };
 
-export { STAGE1_PATHS, STAGE2_PATHS, isFilled };
+const FIELD_GROUPS = ['identity', 'stage1', 'stage2', 'costs', 'process', 'authority', 'mistakes', 'rights', 'expertise', 'brandIdentity'];
+
+/**
+ * Resolve a flat field name to its schema group.
+ * e.g. "transactionCountLastYear" → "stage1"
+ *      "toneOfVoice" → "stage2"
+ *      "awards" → "brandIdentity"
+ * Returns null if the field doesn't exist in any group.
+ */
+firmFactsSchema.statics.resolveFieldGroup = function (fieldName) {
+  const schemaPaths = this.schema.paths;
+  for (const group of FIELD_GROUPS) {
+    if (schemaPaths[`${group}.${fieldName}.value`]) return group;
+  }
+  return null;
+};
+
+export { STAGE1_PATHS, STAGE2_PATHS, isFilled, FIELD_GROUPS };
 export default mongoose.model('FirmFacts', firmFactsSchema);

--- a/routes/firmFactsRoutes.js
+++ b/routes/firmFactsRoutes.js
@@ -17,27 +17,59 @@ router.get('/me', async (req, res) => {
 });
 
 // PUT /api/firmfacts/me — partial update (save-as-you-go)
+// Accepts TWO formats:
+//   1. Flat envelope (frontend): { fieldName: "X", value: Y, source: "self" }
+//   2. Nested paths (legacy/batch): { "group.field": { value: Y, source: "self" }, ... }
 router.put('/me', async (req, res) => {
   try {
     const doc = await FirmFacts.findOrCreateForVendor(req.vendorId);
-    const updates = req.body;
+    const body = req.body;
+    const fieldsUpdated = [];
+    const fieldsSkipped = [];
 
-    for (const [path, val] of Object.entries(updates)) {
-      const parts = path.split('.');
-      if (parts.length !== 2) continue;
-      const [group, field] = parts;
-      if (!doc[group] || typeof doc[group] !== 'object') continue;
-      if (!(field in doc[group])) continue;
+    if (body.fieldName && typeof body.fieldName === 'string') {
+      // ─── Format 1: flat envelope { fieldName, value, source } ───
+      const group = FirmFacts.resolveFieldGroup(body.fieldName);
+      if (group && doc[group] && body.fieldName in doc[group]) {
+        doc[group][body.fieldName] = {
+          value: body.value !== undefined ? body.value : null,
+          filledAt: new Date(),
+          source: body.source || 'self',
+        };
+        fieldsUpdated.push(`${group}.${body.fieldName}`);
+      } else {
+        console.warn(`[FirmFacts PUT] Unknown fieldName: "${body.fieldName}" — no matching group found`);
+        fieldsSkipped.push(body.fieldName);
+      }
+    } else {
+      // ─── Format 2: nested paths { "group.field": { value, source }, ... } ───
+      for (const [path, val] of Object.entries(body)) {
+        const parts = path.split('.');
+        if (parts.length !== 2) {
+          fieldsSkipped.push(path);
+          continue;
+        }
+        const [group, field] = parts;
+        if (!doc[group] || typeof doc[group] !== 'object') {
+          fieldsSkipped.push(path);
+          continue;
+        }
+        if (!(field in doc[group])) {
+          fieldsSkipped.push(path);
+          continue;
+        }
 
-      doc[group][field] = {
-        value: val.value !== undefined ? val.value : val,
-        filledAt: new Date(),
-        source: val.source || 'self',
-      };
+        doc[group][field] = {
+          value: val.value !== undefined ? val.value : val,
+          filledAt: new Date(),
+          source: val.source || 'self',
+        };
+        fieldsUpdated.push(path);
+      }
     }
 
     await doc.save();
-    res.json({ success: true, firmFacts: doc });
+    res.json({ success: true, firmFacts: doc, fieldsUpdated, fieldsSkipped });
   } catch (err) {
     res.status(500).json({ success: false, error: err.message });
   }

--- a/tests/unit/firmFactsRoutes.test.js
+++ b/tests/unit/firmFactsRoutes.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+const VENDOR_A = new mongoose.Types.ObjectId();
+
+// Track what the mock doc receives
+let mockDoc;
+
+const mockFindOrCreate = vi.fn();
+const mockResolveFieldGroup = vi.fn();
+
+vi.mock('../../models/FirmFacts.js', () => {
+  return {
+    STAGE1_PATHS: ['stage1.regulatoryNumber', 'stage1.transactionCountLastYear', 'stage1.typicalAllInCost'],
+    STAGE2_PATHS: [],
+    FIELD_GROUPS: ['identity', 'stage1', 'stage2', 'costs', 'process', 'authority', 'mistakes', 'rights', 'expertise', 'brandIdentity'],
+    isFilled: (f) => f && f.value !== null && f.value !== undefined && !(typeof f.value === 'string' && f.value.trim() === ''),
+    default: {
+      findOrCreateForVendor: (...args) => mockFindOrCreate(...args),
+      resolveFieldGroup: (...args) => mockResolveFieldGroup(...args),
+    },
+  };
+});
+
+vi.mock('../../middleware/vendorAuth.js', () => ({
+  default: (req, _res, next) => {
+    req.vendorId = req.headers['x-test-vendor-id'] || String(VENDOR_A);
+    req.vendor = { id: req.vendorId, vendorId: req.vendorId };
+    next();
+  },
+}));
+
+const { default: express } = await import('express');
+const { default: firmFactsRoutes } = await import('../../routes/firmFactsRoutes.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/firmfacts', firmFactsRoutes);
+  return app;
+}
+
+async function request(app, method, url, { headers = {}, body } = {}) {
+  const { default: http } = await import('http');
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      const opts = {
+        hostname: '127.0.0.1', port, path: url, method: method.toUpperCase(),
+        headers: { 'Content-Type': 'application/json', ...headers },
+      };
+      const req = http.request(opts, (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          server.close();
+          try { resolve({ status: res.statusCode, body: JSON.parse(data) }); }
+          catch { resolve({ status: res.statusCode, body: data }); }
+        });
+      });
+      req.on('error', (err) => { server.close(); reject(err); });
+      if (body) req.write(JSON.stringify(body));
+      req.end();
+    });
+  });
+}
+
+function createMockDoc() {
+  return {
+    vendorId: VENDOR_A,
+    identity: {
+      firmName: { value: null, filledAt: null, source: null },
+      city: { value: null, filledAt: null, source: null },
+      vendorType: { value: null, filledAt: null, source: null },
+      primarySpecialism: { value: null, filledAt: null, source: null },
+      yearEstablished: { value: null, filledAt: null, source: null },
+    },
+    stage1: {
+      regulatoryNumber: { value: null, filledAt: null, source: null },
+      transactionCountLastYear: { value: null, filledAt: null, source: null },
+      typicalAllInCost: { value: null, filledAt: null, source: null },
+    },
+    stage2: {
+      toneOfVoice: { value: null, filledAt: null, source: null },
+      clientTypes: { value: null, filledAt: null, source: null },
+      brandKeywords: { value: null, filledAt: null, source: null },
+      uniqueSellingPoints: { value: null, filledAt: null, source: null },
+      formalComplaintsThisYear: { value: null, filledAt: null, source: null },
+    },
+    expertise: {
+      totalSolicitorCount: { value: null, filledAt: null, source: null },
+    },
+    brandIdentity: {
+      awards: { value: null, filledAt: null, source: null },
+    },
+    save: vi.fn().mockResolvedValue(true),
+    completionPercentage: 0,
+  };
+}
+
+describe('PUT /api/firmfacts/me — envelope format fix', () => {
+  let app;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    mockDoc = createMockDoc();
+    mockFindOrCreate.mockResolvedValue(mockDoc);
+  });
+
+  it('flat envelope: updates stage1 field via fieldName', async () => {
+    mockResolveFieldGroup.mockReturnValue('stage1');
+
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { fieldName: 'transactionCountLastYear', value: 247, source: 'self' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.fieldsUpdated).toContain('stage1.transactionCountLastYear');
+    expect(res.body.fieldsSkipped).toHaveLength(0);
+    expect(mockDoc.stage1.transactionCountLastYear.value).toBe(247);
+    expect(mockDoc.save).toHaveBeenCalled();
+  });
+
+  it('flat envelope: updates stage2 brand field via fieldName', async () => {
+    mockResolveFieldGroup.mockReturnValue('stage2');
+
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { fieldName: 'toneOfVoice', value: 'formal', source: 'self' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fieldsUpdated).toContain('stage2.toneOfVoice');
+    expect(mockDoc.stage2.toneOfVoice.value).toBe('formal');
+  });
+
+  it('flat envelope: unknown fieldName goes to fieldsSkipped', async () => {
+    mockResolveFieldGroup.mockReturnValue(null);
+
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { fieldName: 'nonExistentField', value: 'test', source: 'self' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.fieldsUpdated).toHaveLength(0);
+    expect(res.body.fieldsSkipped).toContain('nonExistentField');
+  });
+
+  it('nested format still works (backwards compat)', async () => {
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { 'stage1.transactionCountLastYear': { value: 500, source: 'self' } },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fieldsUpdated).toContain('stage1.transactionCountLastYear');
+    expect(mockDoc.stage1.transactionCountLastYear.value).toBe(500);
+  });
+
+  it('nested format: invalid path goes to fieldsSkipped', async () => {
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { 'badgroup.badfield': { value: 'x', source: 'self' } },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fieldsUpdated).toHaveLength(0);
+    expect(res.body.fieldsSkipped).toContain('badgroup.badfield');
+  });
+
+  it('response includes fieldsUpdated and fieldsSkipped arrays', async () => {
+    mockResolveFieldGroup.mockReturnValue('stage1');
+
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { fieldName: 'regulatoryNumber', value: '654321', source: 'verified_register' },
+    });
+
+    expect(res.body).toHaveProperty('fieldsUpdated');
+    expect(res.body).toHaveProperty('fieldsSkipped');
+    expect(Array.isArray(res.body.fieldsUpdated)).toBe(true);
+    expect(Array.isArray(res.body.fieldsSkipped)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Critical fix

The PUT /api/firmfacts/me handler was only accepting `{ "group.field": { value, source } }` payloads. The frontend has been sending `{ fieldName, value, source }` since Block 1 shipped. Every field update silently no-op'd because `Object.entries` iteration found keys `"fieldName"`, `"value"`, `"source"` — none of which split into 2 parts on `"."`.

The handler returned `{ success: true }` with the unchanged document, so the frontend's save indicator showed "Saved ✓" while nothing was written to MongoDB.

## What was previously silently failing

Every field the frontend attempted to update via the flat envelope format:
- `transactionCountLastYear`
- `typicalAllInCost`
- `regulatoryNumber`
- `firmName`
- `city`
- `vendorType`
- `primarySpecialism`
- `yearEstablished`
- `toneOfVoice`
- `clientTypes`
- `brandKeywords`
- `uniqueSellingPoints`

All returned `success: true` with zero writes.

## Changes

- **models/FirmFacts.js** (+18 lines): Added `resolveFieldGroup(fieldName)` static method that maps a flat field name to its schema group by checking Mongoose schema paths. Also exports `FIELD_GROUPS` constant.
- **routes/firmFactsRoutes.js** (rewritten, +30 lines net): PUT handler now detects format via `body.fieldName` presence. Flat envelope resolves group via `resolveFieldGroup()`, writes the field. Nested `"group.field"` format still works (backwards compat). Response now includes `fieldsUpdated` and `fieldsSkipped` arrays.
- **tests/unit/firmFactsRoutes.test.js** (new, 6 tests): Covers flat envelope for stage1/stage2/brand fields, unknown field handling, nested format backwards compat, response shape.

## Test results

- 365 passing (+6 new)
- 12 pre-existing failures (unrelated writerAgent mock chain)
- Zero new failures

## How to verify the fix

After merge and deploy:
1. Log in as a Pro vendor on tendorai.com
2. Navigate to /onboarding/firm-facts (or Settings → Firm Facts)
3. Fill in any field (e.g. "Transaction count last year: 247")
4. Save
5. Check MongoDB Atlas → `firmfacts` collection → the vendor's document
6. `stage1.transactionCountLastYear.value` should now be `247` (not `null`)

## Discovered during

Block 2 of frontend onboarding build (PR #73 on tendorai-nextjs). Block 1 (PR #70) and all subsequent testing was silently no-op'ing.

## Linked
- PR #52: FirmFacts model
- PR #53: unified branding + operational schemas

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_