### PR TITLE
chore(firmfacts): surface 500 errors in production logs

### DIFF
--- a/routes/firmFactsRoutes.js
+++ b/routes/firmFactsRoutes.js
@@ -21,6 +21,7 @@ router.get('/me', async (req, res) => {
 //   1. Flat envelope (frontend): { fieldName: "X", value: Y, source: "self" }
 //   2. Nested paths (legacy/batch): { "group.field": { value: Y, source: "self" }, ... }
 router.put('/me', async (req, res) => {
+  console.log('[firmfacts PUT] received body:', JSON.stringify(req.body));
   try {
     const doc = await FirmFacts.findOrCreateForVendor(req.vendorId);
     const body = req.body;
@@ -71,7 +72,11 @@ router.put('/me', async (req, res) => {
     await doc.save();
     res.json({ success: true, firmFacts: doc, fieldsUpdated, fieldsSkipped });
   } catch (err) {
-    res.status(500).json({ success: false, error: err.message });
+    console.error('[firmfacts PUT] error:', err);
+    console.error('[firmfacts PUT] stack:', err.stack);
+    console.error('[firmfacts PUT] vendorId:', req.vendorId);
+    console.error('[firmfacts PUT] body:', JSON.stringify(req.body));
+    res.status(500).json({ success: false, error: err.message, where: 'firmfacts.put' });
   }
 });
 


### PR DESCRIPTION
Debugging blocker. The PUT /api/firmfacts/me handler is throwing 500s in production but errors aren't logged — the catch block only returned `err.message` in the response without any `console.error`.

This commit adds:
- `console.log` of incoming body at handler entry (to see what the frontend actually sends)
- `console.error` of full error, stack trace, vendorId, and body in the catch block
- `err.message` + `where: 'firmfacts.put'` in the 500 response body so Render logs and network tab both show the cause

6 existing tests pass. No logic changes — logging only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_