### PR TITLE
fix(firmfacts): widen source enum to allow onboarding/settings values

### DIFF
--- a/models/FirmFacts.js
+++ b/models/FirmFacts.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const factField = (dataType = mongoose.Schema.Types.Mixed) => ({
   value: { type: dataType, default: null },
   filledAt: { type: Date, default: null },
-  source: { type: String, enum: ['self', 'industry_average', 'estimated', 'verified_register', null], default: null },
+  source: { type: String, enum: ['self', 'industry_average', 'estimated', 'verified_register', 'onboarding', 'onboarding-stage-1', 'onboarding-stage-2', 'onboarding-stage-3', 'settings', 'api', null], default: null },
 });
 
 const firmFactsSchema = new mongoose.Schema({

--- a/tests/unit/firmFactsRoutes.test.js
+++ b/tests/unit/firmFactsRoutes.test.js
@@ -180,4 +180,17 @@ describe('PUT /api/firmfacts/me — envelope format fix', () => {
     expect(Array.isArray(res.body.fieldsUpdated)).toBe(true);
     expect(Array.isArray(res.body.fieldsSkipped)).toBe(true);
   });
+
+  it('flat envelope: accepts onboarding-stage-1 as source value', async () => {
+    mockResolveFieldGroup.mockReturnValue('stage1');
+
+    const res = await request(app, 'PUT', '/api/firmfacts/me', {
+      body: { fieldName: 'typicalAllInCost', value: '£850–£1,500', source: 'onboarding-stage-1' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.fieldsUpdated).toContain('stage1.typicalAllInCost');
+    expect(mockDoc.stage1.typicalAllInCost.source).toBe('onboarding-stage-1');
+  });
 });


### PR DESCRIPTION
Frontend was sending `source: 'onboarding-stage-1'` which wasn't in the Mongoose enum `['self', 'industry_average', 'estimated', 'verified_register']`, causing `ValidationError` on every field save. Discovered via PR #56's error logging.

### Enum change

Before: `['self', 'industry_average', 'estimated', 'verified_register', null]`

After: `['self', 'industry_average', 'estimated', 'verified_register', 'onboarding', 'onboarding-stage-1', 'onboarding-stage-2', 'onboarding-stage-3', 'settings', 'api', null]`

Applied to the `factField` helper which generates every field's `{value, filledAt, source}` structure — so all ~120 fields get the widened enum in one line change.

### Tests
- 366 passing (+1 new asserting `onboarding-stage-1` source works)
- 12 pre-existing failures (unrelated)

### Linked
- PR #55: flat envelope fix
- PR #56: error logging that surfaced this

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_