### PR TITLE
chore: add script to drop stale weeklyreports index and clean orphane…

### DIFF
--- a/scripts/dropStaleWeeklyReportIndex.js
+++ b/scripts/dropStaleWeeklyReportIndex.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import mongoose from 'mongoose';
+
+(async () => {
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(process.env.MONGODB_URI || process.env.MONGO_URI);
+    console.log('Connected.');
+
+    const collection = mongoose.connection.collection('weeklyreports');
+
+    // List existing indexes
+    const indexes = await collection.indexes();
+    console.log('=== Existing indexes ===');
+    indexes.forEach(idx => console.log(JSON.stringify(idx, null, 2)));
+
+    // Drop the stale index
+    try {
+      await collection.dropIndex('vendorId_1_weekStarting_1');
+      console.log('✅ Dropped stale index vendorId_1_weekStarting_1');
+    } catch (err) {
+      if (err.codeName === 'IndexNotFound') {
+        console.log('⚠️  Index vendorId_1_weekStarting_1 not found (already dropped?)');
+      } else {
+        throw err;
+      }
+    }
+
+    // List indexes again
+    const indexesAfter = await collection.indexes();
+    console.log('=== Indexes after cleanup ===');
+    indexesAfter.forEach(idx => console.log(JSON.stringify(idx, null, 2)));
+
+    // Delete any documents from the old schema that have weekStarting
+    // but no weekStartDate (they're orphaned)
+    const orphaned = await collection.countDocuments({
+      weekStarting: { $exists: true },
+      weekStartDate: { $exists: false },
+    });
+    console.log(`Found ${orphaned} orphaned reports from old schema`);
+
+    if (orphaned > 0) {
+      const result = await collection.deleteMany({
+        weekStarting: { $exists: true },
+        weekStartDate: { $exists: false },
+      });
+      console.log(`Deleted ${result.deletedCount} orphaned reports`);
+    }
+
+    // Delete any reports with weekStarting: null from failed dry-runs
+    const failedInserts = await collection.countDocuments({ weekStarting: null });
+    console.log(`Found ${failedInserts} reports with weekStarting: null (from failed dry-runs)`);
+
+    if (failedInserts > 0) {
+      const result = await collection.deleteMany({ weekStarting: null });
+      console.log(`Deleted ${result.deletedCount} failed-insert reports`);
+    }
+
+    await mongoose.disconnect();
+    console.log('Cleanup complete.');
+    process.exit(0);
+  } catch (err) {
+    console.error('Cleanup failed:', err);
+    await mongoose.disconnect().catch(() => {});
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
…d docs

One-off cleanup for PR #58 schema migration. Old schema had compound unique index on { vendorId: 1, weekStarting: 1 }. New schema uses weekStartDate. The stale index causes E11000 duplicate key errors because every new insert has weekStarting: null.

Script drops the index, deletes orphaned old-schema documents, and deletes failed-insert documents with weekStarting: null.

Usage: node scripts/dropStaleWeeklyReportIndex.js

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN