### PR TITLE
feat(writer): vendor-aware CTA + Rule 20 fabrication guard

### DIFF
--- a/routes/vendorPostRoutes.js
+++ b/routes/vendorPostRoutes.js
@@ -33,6 +33,7 @@ export function buildUserPrompt(ctx) {
   const {
     topic, stats, primaryData, verticalLabel, vendorCity,
     vendorName, pillarSpec, vendorTypeEntities, linkedInHookType,
+    ctaUrl, ctaText,
   } = ctx;
 
   const lines = [];
@@ -78,6 +79,12 @@ export function buildUserPrompt(ctx) {
 
   lines.push('');
   lines.push(`LinkedIn hook type for the LinkedIn variant: ${linkedInHookType || 'opinion'}.`);
+
+  if (ctaUrl && ctaText) {
+    lines.push('');
+    lines.push(`CTA for this post: link text = "${ctaText}", link URL = ${ctaUrl}`);
+    lines.push('Use this EXACT URL and text for the closing call-to-action. Do not substitute with any other URL.');
+  }
 
   lines.push('');
   lines.push('Return only the JSON described in the system prompt. No preamble, no markdown fence, no commentary.');

--- a/services/contentPlanner/prompts.js
+++ b/services/contentPlanner/prompts.js
@@ -119,7 +119,7 @@ Paragraphs contain 2-4 sentences, one idea each. No cross-references between sec
 Every H2 block must pass the standalone extraction test: if an AI engine extracts only this H2 section, it reads as a complete, self-contained answer. No block depends on a previous block for context. Do not use phrases like "as noted above", "building on the previous section", or "continuing from". Each H2 section must name its own entities, state its own context, and stand alone.
 
 ### Rule 6 — Single CTA placement (OS Section 16.1)
-One CTA per post, placed after the FAQ block, before the close. CTA format: one sentence of context, one link with a verb. Default destination: /aeo-report (the firm's free AI visibility check). No mid-article CTAs, no urgency language ("act now", "limited time", "don't miss out"), no multiple buttons. UTM format: ?utm_source={post-slug}&utm_medium=blog&utm_campaign={cluster}&utm_content=in-article-cta
+One CTA per post, placed after the FAQ block, before the close. Use the EXACT ctaUrl and ctaText provided in the input — do NOT default to tendorai.com/aeo-report unless that URL is explicitly provided. CTA format: one conversational sentence of context, then a markdown link [exact ctaText](exact ctaUrl). No mid-article CTAs, no urgency language ("act now", "limited time", "don't miss out"), no multiple buttons.
 
 ### Rule 7 — Worked £ example (OS Section 17)
 On pillar, comparison, or pricing pages: include at least one worked £ example showing a realistic total cost. Use Tier 0 data from firm_context where available. Where unavailable, use [FIRM TO PROVIDE: worked example with total cost]. On non-pricing pages, this rule does not apply.
@@ -239,6 +239,34 @@ Regulatory references: Cite Propertymark / NAEA / ARLA guidance, TPO/PRS scheme 
 Compliance: Pages must reflect current AML requirements, material information rules, and Right to Rent requirements where relevant. Do not guarantee sale prices, rental yields, or timescales.
 
 Five-bullet citable summary format for estate agent posts: each bullet leads with a regulatory body, a legislation name, a scheme, a process stage, or a market-specific fact.
+
+## RULE 20 — STATISTICS AND ATTRIBUTION (absolute, no exceptions)
+
+NEVER fabricate a statistic and attribute it to a named body (Propertymark, The Property Ombudsman, RICS, NAEA, ARLA, SRA, FCA, ICAEW, ACCA, AAT, ONS, gov.uk, Companies House, Land Registry, HMRC, CMA, Financial Ombudsman, TPO, or any other regulator, trade body, or government source).
+
+If you do not have a verified source URL in your input, you may NOT:
+- Cite a specific percentage attributed to that body
+- Cite a specific count (e.g. "45,000 transactions") attributed to that body
+- Cite a specific time period of data attributed to that body
+- Imply that body has published a study, report, or analysis you cannot verify
+
+ALLOWED instead:
+- General industry knowledge without specific numbers ("conveyancing fees vary widely")
+- Qualitative claims without specific numbers ("traditional agents typically achieve higher sale prices")
+- Facts from the firm_context block (Tier 0 data — these are real)
+- Tier 1 regulator-published thresholds you can cite by rule name (e.g. SDLT thresholds, SRA Transparency Rules)
+
+FORBIDDEN examples:
+- "Propertymark analysis of 45,000 transactions shows..." ❌
+- "RICS data indicates 73% of conveyancers..." ❌
+- "According to the Property Ombudsman's 2024 report, 89%..." ❌
+
+ALLOWED examples:
+- "Traditional estate agents often achieve higher final sale prices than online agents, though this varies by property type." ✅
+- "Conveyancing fees in England and Wales typically range from £800 to £2,000." ✅
+- "Industry data suggests online conveyancing has grown sharply since 2020." ✅
+
+If you find yourself wanting to write a number attributed to a body, ask: do I have a verified source for this exact claim? If no, use qualitative language instead.
 
 ## BODY STRUCTURE
 

--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -1,0 +1,64 @@
+const REGULATORY_BODIES = [
+  'Propertymark', 'Property Ombudsman', 'RICS', 'NAEA', 'ARLA',
+  'SRA', 'FCA', 'ICAEW', 'ACCA', 'AAT', 'ONS', 'gov\\.uk',
+  'Companies House', 'Land Registry', 'HMRC', 'CMA', 'FOS',
+  'Financial Ombudsman', 'TPO',
+];
+
+const DATA_VERBS = [
+  'shows', 'reveals', 'analysis', 'report', 'study', 'research',
+  'data', 'survey', 'found', 'indicates', 'reports',
+];
+
+export function buildCtaForVendor(vendor) {
+  const proTiers = new Set(['pro', 'verified', 'managed', 'enterprise']);
+  if (proTiers.has(vendor.tier)) {
+    const slug = vendor.slug || vendor.company?.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    return {
+      ctaUrl: `https://www.tendorai.com/suppliers/vendor/${slug}`,
+      ctaText: `Get in touch with ${vendor.company}`,
+    };
+  }
+  return {
+    ctaUrl: 'https://www.tendorai.com/aeo-report',
+    ctaText: 'Get your free AI Visibility Report',
+  };
+}
+
+export function detectPossibleFabrication(draftText) {
+  if (!draftText || typeof draftText !== 'string') return [];
+
+  const flagged = [];
+  const verbPattern = DATA_VERBS.join('|');
+
+  const numberPattern = '(\\d+[,.]?\\d*\\%?|\\d{1,3}(,\\d{3})+)';
+
+  for (const body of REGULATORY_BODIES) {
+    const cleanBody = body.replace(/\\\./g, '.');
+
+    // Pattern A: body → number → verb (e.g. "Propertymark analysis of 45,000 transactions shows")
+    const patternA = new RegExp(body + '[^.]{0,200}' + numberPattern + '[^.]{0,200}(' + verbPattern + ')', 'gi');
+    // Pattern B: body → verb → number (e.g. "RICS data indicates 73%")
+    const patternB = new RegExp(body + '[^.]{0,100}(' + verbPattern + ')[^.]{0,200}' + numberPattern, 'gi');
+    // Pattern C: verb → body → number (e.g. "According to the Property Ombudsman... 89%")
+    const patternC = new RegExp('(' + verbPattern + ')[^.]{0,100}' + body + '[^.]{0,200}' + numberPattern, 'gi');
+
+    for (const pat of [patternA, patternB, patternC]) {
+      let match;
+      while ((match = pat.exec(draftText)) !== null) {
+        const alreadyFlagged = flagged.some(f => Math.abs(f.position - match.index) < 50);
+        if (!alreadyFlagged) {
+          flagged.push({
+            body: cleanBody,
+            excerpt: match[0].substring(0, 200),
+            position: match.index,
+          });
+        }
+      }
+    }
+  }
+
+  return flagged;
+}
+
+export { REGULATORY_BODIES, DATA_VERBS };

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -7,6 +7,7 @@ import { countPlaceholders } from './contentPlanner/validators.js';
 import { buildUserPrompt } from '../routes/vendorPostRoutes.js';
 import { findOrCreateRun, startRun, completeRun, failRun } from './agentRun.js';
 import { createApproval } from './approvalQueue.js';
+import { buildCtaForVendor, detectPossibleFabrication } from './contentPlanner/writerGuards.js';
 
 const SONNET_INPUT_COST_PER_M = 3.00;
 const SONNET_OUTPUT_COST_PER_M = 15.00;
@@ -151,6 +152,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
   }
   const firmContextBlock = renderFirmContextBlock(firmContext);
 
+  const cta = buildCtaForVendor(vendor);
   const userPrompt = buildUserPrompt({
     topic: topicTitle,
     stats: '',
@@ -161,6 +163,8 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
     pillarSpec,
     vendorTypeEntities,
     linkedInHookType: next.topic.linkedInHookType || 'opinion',
+    ctaUrl: cta.ctaUrl,
+    ctaText: cta.ctaText,
   });
 
   let response;
@@ -262,6 +266,12 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
     };
   }
 
+  // Rule 20 fabrication guard — scan before saving
+  const fabricationFlags = detectPossibleFabrication(parsed.body || '');
+  if (fabricationFlags.length > 0) {
+    console.warn(`[WriterAgent] Draft for ${vendor.company} contains ${fabricationFlags.length} possible fabrication(s)`);
+  }
+
   const approval = await createApproval({
     vendorId,
     agentName: 'writer',
@@ -301,6 +311,9 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
       topicSuitabilityFlag,
       agentReportedPlaceholderCount,
       ...(dryRun ? { dryRun: true } : {}),
+      ...(fabricationFlags.length > 0 ? {
+        qualityFlags: [{ type: 'possible_fabrication', detected: fabricationFlags, severity: 'high' }],
+      } : {}),
     },
     source: 'writer-agent-cron',
   });

--- a/tests/unit/writerAgentFixes.test.js
+++ b/tests/unit/writerAgentFixes.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { buildCtaForVendor, detectPossibleFabrication } from '../../services/contentPlanner/writerGuards.js';
+
+describe('buildCtaForVendor', () => {
+  it('returns vendor profile URL for Pro vendor', () => {
+    const cta = buildCtaForVendor({ tier: 'pro', slug: 'harrison-co', company: 'Harrison & Co' });
+    expect(cta.ctaUrl).toBe('https://www.tendorai.com/suppliers/vendor/harrison-co');
+    expect(cta.ctaText).toBe('Get in touch with Harrison & Co');
+  });
+
+  it('returns vendor profile URL for verified vendor', () => {
+    const cta = buildCtaForVendor({ tier: 'verified', slug: 'test-firm', company: 'Test Firm' });
+    expect(cta.ctaUrl).toContain('/suppliers/vendor/test-firm');
+  });
+
+  it('returns vendor profile URL for managed vendor', () => {
+    const cta = buildCtaForVendor({ tier: 'managed', slug: 'cardiff-pp', company: 'Cardiff PP' });
+    expect(cta.ctaUrl).toContain('/suppliers/vendor/cardiff-pp');
+  });
+
+  it('returns AEO funnel URL for free vendor', () => {
+    const cta = buildCtaForVendor({ tier: 'free', slug: 'free-firm', company: 'Free Firm' });
+    expect(cta.ctaUrl).toBe('https://www.tendorai.com/aeo-report');
+    expect(cta.ctaText).toBe('Get your free AI Visibility Report');
+  });
+});
+
+describe('detectPossibleFabrication', () => {
+  it('catches "Propertymark analysis of 45,000 transactions shows..."', () => {
+    const text = 'Propertymark analysis of 45,000 transactions shows that traditional agents achieve 97.2% of asking price.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBeGreaterThan(0);
+    expect(flagged[0].body).toBe('Propertymark');
+  });
+
+  it('catches "RICS data indicates 73%..."', () => {
+    const text = 'RICS data indicates 73% of conveyancers comply with the new framework.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('catches "According to the Property Ombudsman..."', () => {
+    const text = 'According to the Property Ombudsman, complaints rose by 12% in their 2024 report.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag qualitative claims without numbers', () => {
+    const text = 'Traditional estate agents often achieve higher final sale prices than online agents, though this varies by property type.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged).toHaveLength(0);
+  });
+
+  it('does NOT flag generic price ranges without attributed bodies', () => {
+    const text = 'Conveyancing fees in England and Wales typically range from £800 to £2,000.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged).toHaveLength(0);
+  });
+
+  it('does NOT flag generic qualitative industry claims', () => {
+    const text = 'Industry data suggests online conveyancing has grown sharply since 2020. Many firms now offer fixed fees.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Two fixes before Wednesday's Writer cron (21 May 05:00 UTC)

### Fix 1 — Vendor-aware CTA routing

**Before:** Every draft ended with a CTA linking to `tendorai.com/aeo-report` regardless of which vendor commissioned the content. AI traffic flowed to TendorAI's marketing funnel, not to the firm.

**After:** Pro/verified/managed vendors get a CTA pointing to their own TendorAI profile page:
```
[Get in touch with Cardiff Property Partners](https://www.tendorai.com/suppliers/vendor/cardiff-property-partners)
```
Free tier vendors still get the AEO report CTA.

**Implementation:**
- New `buildCtaForVendor(vendor)` in `services/contentPlanner/writerGuards.js`
- `ctaUrl` + `ctaText` passed through `buildUserPrompt()` to the Claude prompt
- System prompt Rule 6 updated: "Use the EXACT ctaUrl and ctaText provided in the input"

### Fix 2 — Rule 20 fabrication guard

**Problem:** Drafts were inventing statistics and attributing them to real bodies. Example from last week:
> "Propertymark analysis of 45,000 transactions shows traditional agents achieve 97.2% of asking price on average"

Propertymark never published that analysis.

**Prompt-side fix:** New Rule 20 added to `SYSTEM_PROMPT_WRITER_V1_1` with:
- Explicit list of 19 protected bodies (Propertymark, RICS, SRA, FCA, ICAEW, etc.)
- Forbidden vs allowed output examples
- Instruction to use qualitative language when no verified source URL exists

**Validator-side fix:** `detectPossibleFabrication(text)` scans drafts for the pattern `[Named Body] + [number] + [data verb]` in any sentence order (3 regex patterns per body × 19 bodies × 11 verbs).

Flagged drafts are saved with `metadata.qualityFlags = [{ type: 'possible_fabrication', severity: 'high' }]` visible in the admin approval queue. Does NOT auto-reject — human review is the final filter.

### Files changed

| File | Change |
|------|--------|
| `services/contentPlanner/prompts.js` | Rule 6 CTA update + Rule 20 fabrication guard |
| `services/contentPlanner/writerGuards.js` | New: `buildCtaForVendor()` + `detectPossibleFabrication()` |
| `services/writerAgent.js` | Import guards, pass CTA, run fabrication scan before approval creation |
| `routes/vendorPostRoutes.js` | `buildUserPrompt()` accepts + passes `ctaUrl`/`ctaText` |
| `tests/unit/writerAgentFixes.test.js` | 10 new tests |

### Test results

- 411 passing (+10 new)
- 12 pre-existing failures (unrelated writerAgent mock chain)

### Test coverage

1. `buildCtaForVendor` — pro, verified, managed → vendor profile URL
2. `buildCtaForVendor` — free → AEO funnel URL
3. `detectPossibleFabrication` catches "Propertymark analysis of 45,000..."
4. `detectPossibleFabrication` catches "RICS data indicates 73%..."
5. `detectPossibleFabrication` catches "According to the Property Ombudsman..."
6. `detectPossibleFabrication` does NOT flag qualitative claims
7. `detectPossibleFabrication` does NOT flag generic price ranges
8. `detectPossibleFabrication` does NOT flag generic industry claims

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_