### PR TITLE
feat(vendor): add isDemoAccount field, replace hardcoded DEMO_VENDOR_IDS

### DIFF
--- a/jobs/scheduledReports.js
+++ b/jobs/scheduledReports.js
@@ -348,10 +348,6 @@ export function startScheduledReports() {
       const { default: WeeklyReport } = await import('../models/WeeklyReport.js');
       const { default: Vendor } = await import('../models/Vendor.js');
 
-      const DEMO_VENDOR_IDS = new Set([
-        '699757a97712b4369510e6c8', // Cardiff Property Partners
-      ]);
-
       function getMondayOfThisWeek() {
         const now = new Date();
         const day = now.getUTCDay();
@@ -368,7 +364,7 @@ export function startScheduledReports() {
           { tier: { $in: PRO_TIER_VALUES } },
           { 'account.tier': { $in: PRO_ACCOUNT_TIERS } },
         ],
-      }).select('_id company email location tier').lean();
+      }).select('_id company email location tier isDemoAccount').lean();
 
       logger.info(`[Reporter] Found ${vendors.length} Pro vendor(s)`);
 
@@ -411,10 +407,9 @@ export function startScheduledReports() {
           }
 
           // Email — skip demo vendors and placeholder emails
-          const isDemo = DEMO_VENDOR_IDS.has(vid);
           const hasValidEmail = vendor.email && !vendor.email.includes('@placeholder.tendorai.com');
 
-          if (isDemo) {
+          if (vendor.isDemoAccount) {
             logger.info(`[Reporter] ${vendor.company}: demo vendor — email skipped`);
             skippedDemo++;
             continue;

--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -392,7 +392,9 @@ const vendorSchema = new mongoose.Schema({
     trim: true,
     lowercase: true,
     index: true
-  }
+  },
+
+  isDemoAccount: { type: Boolean, default: false, index: true },
 
 }, {
   timestamps: true,

--- a/scripts/setIsDemoAccountForCardiff.js
+++ b/scripts/setIsDemoAccountForCardiff.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/**
+ * One-off: set isDemoAccount: true for Cardiff Property Partners.
+ * Delete after running.
+ *
+ * Usage: node scripts/setIsDemoAccountForCardiff.js
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import mongoose from 'mongoose';
+import Vendor from '../models/Vendor.js';
+
+(async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI || process.env.MONGO_URI);
+
+    const result = await Vendor.updateOne(
+      { _id: '699757a97712b4369510e6c8' },
+      { $set: { isDemoAccount: true } }
+    );
+    console.log(`Modified: ${result.modifiedCount}`);
+
+    const v = await Vendor.findById('699757a97712b4369510e6c8').select('company isDemoAccount tier').lean();
+    console.log(`${v?.company} isDemoAccount: ${v?.isDemoAccount} tier: ${v?.tier}`);
+
+    await mongoose.disconnect();
+    process.exit(0);
+  } catch (err) {
+    console.error('Failed:', err);
+    await mongoose.disconnect().catch(() => {});
+    process.exit(1);
+  }
+})();

--- a/tests/unit/reporterCronWiring.test.js
+++ b/tests/unit/reporterCronWiring.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('Reporter Cron Wiring', () => {
-  const DEMO_VENDOR_IDS = new Set(['699757a97712b4369510e6c8']);
 
   function getMondayOfThisWeek() {
     const now = new Date();
@@ -19,9 +18,14 @@ describe('Reporter Cron Wiring', () => {
     expect(monday.getUTCMinutes()).toBe(0);
   });
 
-  it('demo vendor IDs are gated correctly', () => {
-    expect(DEMO_VENDOR_IDS.has('699757a97712b4369510e6c8')).toBe(true);
-    expect(DEMO_VENDOR_IDS.has('000000000000000000000000')).toBe(false);
+  it('vendor.isDemoAccount gates demo vendors correctly', () => {
+    const demoVendor = { _id: '699757a97712b4369510e6c8', company: 'Cardiff Property Partners', isDemoAccount: true };
+    const realVendor = { _id: 'aaaaaaaaaaaaaaaaaaaaaaaa', company: 'Real Firm', isDemoAccount: false };
+    const unsetVendor = { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb', company: 'Old Firm' };
+
+    expect(demoVendor.isDemoAccount).toBe(true);
+    expect(realVendor.isDemoAccount).toBe(false);
+    expect(!!unsetVendor.isDemoAccount).toBe(false);
   });
 
   it('PRO_TIER_VALUES includes managed, verified, enterprise, pro', () => {
@@ -43,26 +47,27 @@ describe('Reporter Cron Wiring', () => {
     expect(isPlaceholder('client@example.com')).toBe(false);
   });
 
-  it('demo vendors still get report but no email', () => {
-    const vendor = { _id: '699757a97712b4369510e6c8', company: 'Cardiff Property Partners', email: 'kinder1975.sd@gmail.com' };
-    const isDemo = DEMO_VENDOR_IDS.has(String(vendor._id));
-    expect(isDemo).toBe(true);
+  it('demo vendor gets report generated but email skipped', () => {
+    const vendor = { _id: '699757a97712b4369510e6c8', company: 'Cardiff Property Partners', email: 'kinder1975.sd@gmail.com', isDemoAccount: true };
+    expect(vendor.isDemoAccount).toBe(true);
     // Report should be generated (not skipped)
-    // Email should be skipped
+    // Email should be skipped because isDemoAccount is true
   });
 
-  it('non-demo vendor with valid email gets email', () => {
-    const vendor = { _id: 'aaaaaaaaaaaaaaaaaaaaaaaa', company: 'Real Firm', email: 'real@example.com' };
-    const isDemo = DEMO_VENDOR_IDS.has(String(vendor._id));
+  it('non-demo vendor with valid email gets report + email', () => {
+    const vendor = { _id: 'aaaaaaaaaaaaaaaaaaaaaaaa', company: 'Real Firm', email: 'real@example.com', isDemoAccount: false };
     const hasValidEmail = vendor.email && !vendor.email.includes('@placeholder.tendorai.com');
-    expect(isDemo).toBe(false);
+    expect(vendor.isDemoAccount).toBe(false);
     expect(hasValidEmail).toBe(true);
   });
 
+  it('isDemoAccount defaults to false on new vendor', () => {
+    const newVendor = { company: 'Brand New Firm', tier: 'managed' };
+    expect(newVendor.isDemoAccount ?? false).toBe(false);
+  });
+
   it('idempotency: existing report for same week should be skipped', () => {
-    // Simulate: WeeklyReport.findOne returns a doc
     const existing = { _id: 'abc', reportNumber: 'AVI-TEST-2026-W21' };
     expect(existing).not.toBeNull();
-    // Cron should skip this vendor and log "already exists"
   });
 });


### PR DESCRIPTION
## What this does

Replaces the hardcoded `DEMO_VENDOR_IDS` Set in the Reporter cron with a schema-level `isDemoAccount` boolean on the Vendor model. Demo status is now toggleable from the database (and future admin UI) without code changes.

### Before
```javascript
const DEMO_VENDOR_IDS = new Set(['699757a97712b4369510e6c8']);
// ...
const isDemo = DEMO_VENDOR_IDS.has(vid);
```

### After
```javascript
// On the Vendor model:
isDemoAccount: { type: Boolean, default: false, index: true }

// In the cron:
if (vendor.isDemoAccount) {
  logger.info(`[Reporter] ${vendor.company}: demo vendor — email skipped`);
}
```

## Changes

| File | Change |
|------|--------|
| `models/Vendor.js` | Add `isDemoAccount` field (Boolean, default false, indexed) |
| `jobs/scheduledReports.js` | Remove `DEMO_VENDOR_IDS` Set, add `isDemoAccount` to vendor select, use `vendor.isDemoAccount` in gate |
| `scripts/setIsDemoAccountForCardiff.js` | One-off migration to set `isDemoAccount: true` for Cardiff Property Partners. Delete after running. |
| `tests/unit/reporterCronWiring.test.js` | Rewritten: `DEMO_VENDOR_IDS.has()` → `vendor.isDemoAccount`, added defaults-to-false test |

## Migration

After merge:
```bash
node scripts/setIsDemoAccountForCardiff.js
```

## Tests

- 429 passing (+1 net)
- 12 pre-existing failures (unrelated)

## Behaviour preserved

- Demo vendors: report generated, email skipped (same as before)
- Non-demo vendors: report generated + email sent (same as before)
- New vendors: `isDemoAccount` defaults to `false` (no change needed)

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_