### PR TITLE
fix(vendor): conditional city append in slug + previousSlugs for 301 redirects

### DIFF
--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -396,6 +396,8 @@ const vendorSchema = new mongoose.Schema({
 
   isDemoAccount: { type: Boolean, default: false, index: true },
 
+  previousSlugs: { type: [String], default: [], index: true },
+
 }, {
   timestamps: true,
   toJSON: { virtuals: true },
@@ -441,10 +443,13 @@ vendorSchema.pre('save', function(next) {
       .replace(/-+/g, '-')
       .trim();
     if (this.location?.city) {
-      this.slug += '-' + this.location.city
+      const citySlug = this.location.city
         .toLowerCase()
         .replace(/[^a-z0-9\s-]/g, '')
         .replace(/\s+/g, '-');
+      if (citySlug && !this.slug.includes(citySlug)) {
+        this.slug += '-' + citySlug;
+      }
     }
   }
   next();

--- a/routes/publicApiRoutes.js
+++ b/routes/publicApiRoutes.js
@@ -209,15 +209,26 @@ router.get('/vendors/:slug', async (req, res) => {
   try {
     const { slug } = req.params;
 
-    const vendor = await Vendor.findOne({ slug, ...ACTIVE_FILTER })
-      .select('company vendorType services practiceAreas location contactInfo businessProfile performance sraNumber icaewFirmNumber fcaNumber propertymarkNumber regulatoryBody slug claimedAt listingStatus tier account.tier')
+    let vendor = await Vendor.findOne({ slug, ...ACTIVE_FILTER })
+      .select('company vendorType services practiceAreas location contactInfo businessProfile performance sraNumber icaewFirmNumber fcaNumber propertymarkNumber regulatoryBody slug previousSlugs claimedAt listingStatus tier account.tier')
       .lean();
+
+    let redirectSlug = null;
+    if (!vendor) {
+      // Check previousSlugs for 301 redirect support
+      vendor = await Vendor.findOne({ previousSlugs: slug, ...ACTIVE_FILTER })
+        .select('company vendorType services practiceAreas location contactInfo businessProfile performance sraNumber icaewFirmNumber fcaNumber propertymarkNumber regulatoryBody slug previousSlugs claimedAt listingStatus tier account.tier')
+        .lean();
+      if (vendor) redirectSlug = vendor.slug;
+    }
 
     if (!vendor) {
       return res.status(404).json(wrapResponse({ error: 'Vendor not found' }));
     }
 
-    res.json(wrapResponse({ vendor: formatVendor(vendor) }));
+    const response = { vendor: formatVendor(vendor) };
+    if (redirectSlug) response.redirectSlug = redirectSlug;
+    res.json(wrapResponse(response));
   } catch (err) {
     console.error('Public API vendor error:', err);
     res.status(500).json(wrapResponse({ error: 'Internal server error' }));

--- a/scripts/migrateSlugDuplication.js
+++ b/scripts/migrateSlugDuplication.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * One-off: fix city-duplicated vendor slugs.
+ * e.g. 'cardiff-property-partners-cardiff' → 'cardiff-property-partners'
+ * Old slugs stored in vendor.previousSlugs[] for 301 redirect lookup.
+ * Delete after running.
+ *
+ * Usage: node scripts/migrateSlugDuplication.js
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import mongoose from 'mongoose';
+import Vendor from '../models/Vendor.js';
+
+function slugifyText(text) {
+  return (text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+function computeCleanSlug(company, city) {
+  const companySlug = slugifyText(company);
+  if (!city) return companySlug;
+  const citySlug = slugifyText(city);
+  if (citySlug && !companySlug.includes(citySlug)) {
+    return `${companySlug}-${citySlug}`;
+  }
+  return companySlug;
+}
+
+(async () => {
+  try {
+    console.log('=== Migrate Slug Duplication ===\n');
+    await mongoose.connect(process.env.MONGODB_URI || process.env.MONGO_URI);
+
+    const vendors = await Vendor.find({
+      slug: { $exists: true, $ne: null },
+      'location.city': { $exists: true, $ne: '' },
+    }).select('_id company slug location.city previousSlugs').lean();
+
+    console.log(`Found ${vendors.length} vendors with slug + city.\n`);
+
+    let updated = 0;
+    let unchanged = 0;
+    let skippedConflict = 0;
+
+    for (const v of vendors) {
+      const cleanSlug = computeCleanSlug(v.company, v.location?.city);
+
+      if (cleanSlug === v.slug) {
+        unchanged++;
+        continue;
+      }
+
+      // Check uniqueness
+      const taken = await Vendor.findOne({ slug: cleanSlug, _id: { $ne: v._id } });
+      if (taken) {
+        console.log(`  SKIP: ${v.company} — clean slug '${cleanSlug}' already taken by ${taken.company}`);
+        skippedConflict++;
+        continue;
+      }
+
+      await Vendor.updateOne(
+        { _id: v._id },
+        {
+          $set: { slug: cleanSlug },
+          $addToSet: { previousSlugs: v.slug },
+        }
+      );
+
+      updated++;
+      console.log(`  ✅ ${v.company}: '${v.slug}' → '${cleanSlug}'`);
+    }
+
+    console.log('\n=== Summary ===');
+    console.log(`Updated:  ${updated}`);
+    console.log(`Unchanged: ${unchanged}`);
+    console.log(`Skipped (conflict): ${skippedConflict}`);
+
+    await mongoose.disconnect();
+    process.exit(0);
+  } catch (err) {
+    console.error('Migration failed:', err);
+    await mongoose.disconnect().catch(() => {});
+    process.exit(1);
+  }
+})();
+
+export { computeCleanSlug, slugifyText };

--- a/tests/unit/vendorSlug.test.js
+++ b/tests/unit/vendorSlug.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { computeCleanSlug, slugifyText } from '../../scripts/migrateSlugDuplication.js';
+
+describe('Vendor Slug — city duplication fix', () => {
+  describe('slugifyText', () => {
+    it('lowercases and replaces spaces with hyphens', () => {
+      expect(slugifyText('Cardiff Property Partners')).toBe('cardiff-property-partners');
+    });
+
+    it('strips special characters', () => {
+      expect(slugifyText("Smith & Co's")).toBe('smith-cos');
+    });
+
+    it('handles empty/null', () => {
+      expect(slugifyText('')).toBe('');
+      expect(slugifyText(null)).toBe('');
+    });
+  });
+
+  describe('computeCleanSlug', () => {
+    it('does NOT duplicate city when company contains city', () => {
+      const slug = computeCleanSlug('Cardiff Property Partners', 'Cardiff');
+      expect(slug).toBe('cardiff-property-partners');
+      expect(slug).not.toContain('cardiff-cardiff');
+    });
+
+    it('appends city when company does NOT contain city', () => {
+      const slug = computeCleanSlug('Smith & Co', 'London');
+      expect(slug).toBe('smith-co-london');
+    });
+
+    it('handles company already ending with city', () => {
+      const slug = computeCleanSlug('Best Solicitors Cardiff', 'Cardiff');
+      expect(slug).toBe('best-solicitors-cardiff');
+    });
+
+    it('handles no city', () => {
+      const slug = computeCleanSlug('Generic Firm', null);
+      expect(slug).toBe('generic-firm');
+    });
+
+    it('handles empty city', () => {
+      const slug = computeCleanSlug('Generic Firm', '');
+      expect(slug).toBe('generic-firm');
+    });
+
+    it('handles multi-word city', () => {
+      const slug = computeCleanSlug('North Wales Solicitors', 'North Wales');
+      expect(slug).toBe('north-wales-solicitors');
+      expect(slug).not.toContain('north-wales-north-wales');
+    });
+  });
+
+  describe('previousSlugs lookup', () => {
+    it('old slug stored in previousSlugs after migration', () => {
+      const oldSlug = 'cardiff-property-partners-cardiff';
+      const newSlug = 'cardiff-property-partners';
+      const previousSlugs = [oldSlug];
+      expect(previousSlugs).toContain(oldSlug);
+      expect(newSlug).not.toBe(oldSlug);
+    });
+
+    it('vendor findable by previousSlugs value', () => {
+      const vendor = {
+        slug: 'cardiff-property-partners',
+        previousSlugs: ['cardiff-property-partners-cardiff'],
+      };
+      const searchSlug = 'cardiff-property-partners-cardiff';
+      const foundViaCurrent = vendor.slug === searchSlug;
+      const foundViaPrevious = vendor.previousSlugs.includes(searchSlug);
+      expect(foundViaCurrent).toBe(false);
+      expect(foundViaPrevious).toBe(true);
+    });
+
+    it('redirectSlug returned when found via previousSlugs', () => {
+      const vendor = { slug: 'cardiff-property-partners' };
+      const requestedSlug = 'cardiff-property-partners-cardiff';
+      const redirectSlug = vendor.slug !== requestedSlug ? vendor.slug : null;
+      expect(redirectSlug).toBe('cardiff-property-partners');
+    });
+  });
+});


### PR DESCRIPTION
## Resolves PR #76 audit

Fixes the slug generation bug where city is unconditionally appended to company name, producing duplicates like `cardiff-property-partners-cardiff`.

### The bug

`models/Vendor.js:443` — pre-save hook always appends `location.city`:

```javascript
// Before:
this.slug += '-' + this.location.city.toLowerCase()...;

// After:
const citySlug = this.location.city.toLowerCase()...;
if (citySlug && !this.slug.includes(citySlug)) {
  this.slug += '-' + citySlug;
}
```

### Changes

| File | Change |
|------|--------|
| `models/Vendor.js` | Conditional city append + `previousSlugs: [String]` field |
| `routes/publicApiRoutes.js` | `GET /vendors/:slug` falls back to `previousSlugs` lookup, returns `redirectSlug` for frontend 301 |
| `scripts/migrateSlugDuplication.js` | One-off: compute clean slugs, store old in `previousSlugs`, check uniqueness |
| `tests/unit/vendorSlug.test.js` | 12 tests |

### After migration

Cardiff Property Partners:
- Old slug: `cardiff-property-partners-cardiff`
- New slug: `cardiff-property-partners`
- `previousSlugs: ['cardiff-property-partners-cardiff']`
- Old URL still works → API returns `{ redirectSlug: 'cardiff-property-partners' }` → frontend 301s

### Frontend 301

Separate PR in `tendorai-nextjs`: when API returns `redirectSlug`, frontend does `router.replace(/suppliers/vendor/${redirectSlug})`.

### Tests

441 passing (+12 new), 12 pre-existing failures.

### Post-merge

```bash
node scripts/migrateSlugDuplication.js
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_