### PR TITLE
fix(public): vendor profile route CastError — lookup by _id not slug

### DIFF
--- a/routes/publicVendorRoutes.js
+++ b/routes/publicVendorRoutes.js
@@ -410,19 +410,36 @@ router.get('/vendors/search', async (req, res) => {
 
 /**
  * GET /api/public/vendors/:id
- * Get single vendor profile with badges and tier-based visibility
+ * Get single vendor profile with badges and tier-based visibility.
+ * Accepts ObjectId OR slug. Falls back to previousSlugs for 301 redirect support.
  */
 router.get('/vendors/:id', async (req, res) => {
   try {
     const { id } = req.params;
 
-    const vendor = await Vendor.findOne({
-      _id: id,
+    const activeFilter = {
       $or: [
         { 'account.status': 'active', 'account.verificationStatus': 'verified' },
-        { listingStatus: 'unclaimed' }
-      ]
-    }).lean();
+        { listingStatus: 'unclaimed' },
+      ],
+    };
+
+    // Try ObjectId first, then slug, then previousSlugs
+    let vendor = null;
+    let redirectSlug = null;
+
+    if (id.match(/^[0-9a-fA-F]{24}$/)) {
+      vendor = await Vendor.findOne({ _id: id, ...activeFilter }).lean();
+    }
+
+    if (!vendor) {
+      vendor = await Vendor.findOne({ slug: id, ...activeFilter }).lean();
+    }
+
+    if (!vendor) {
+      vendor = await Vendor.findOne({ previousSlugs: id, ...activeFilter }).lean();
+      if (vendor) redirectSlug = vendor.slug;
+    }
 
     if (!vendor) {
       return res.status(404).json({
@@ -543,7 +560,9 @@ router.get('/vendors/:id', async (req, res) => {
       };
     }
 
-    res.json({ success: true, data: profileData });
+    const response = { success: true, data: profileData };
+    if (redirectSlug) response.redirectSlug = redirectSlug;
+    res.json(response);
 
   } catch (error) {
     console.error('Vendor profile error:', error);

--- a/tests/unit/vendorSlug.test.js
+++ b/tests/unit/vendorSlug.test.js
@@ -79,4 +79,37 @@ describe('Vendor Slug — city duplication fix', () => {
       expect(redirectSlug).toBe('cardiff-property-partners');
     });
   });
+
+  describe('publicVendorRoutes slug-or-id lookup', () => {
+    it('ObjectId format triggers _id lookup first', () => {
+      const id = '699757a97712b4369510e6c8';
+      expect(id.match(/^[0-9a-fA-F]{24}$/)).toBeTruthy();
+    });
+
+    it('slug format does NOT match ObjectId regex', () => {
+      const slug = 'cardiff-property-partners';
+      expect(slug.match(/^[0-9a-fA-F]{24}$/)).toBeNull();
+    });
+
+    it('lookup chain: _id → slug → previousSlugs', () => {
+      // Simulates the 3-step lookup
+      const vendors = {
+        byId: null,
+        bySlug: null,
+        byPreviousSlug: { slug: 'cardiff-property-partners', previousSlugs: ['cardiff-property-partners-cardiff'] },
+      };
+      const searchParam = 'cardiff-property-partners-cardiff';
+
+      let vendor = vendors.byId;
+      let redirectSlug = null;
+      if (!vendor) vendor = vendors.bySlug;
+      if (!vendor) {
+        vendor = vendors.byPreviousSlug;
+        if (vendor) redirectSlug = vendor.slug;
+      }
+
+      expect(vendor).not.toBeNull();
+      expect(redirectSlug).toBe('cardiff-property-partners');
+    });
+  });
 });


### PR DESCRIPTION
## Production bug fix

Production logs show:
```
Vendor profile error: CastError: Cast to ObjectId failed for value 
"cardiff-property-partners" (type string) at path "_id" for model "Vendor"
at async publicVendorRoutes.js:419
```

### Root cause

`GET /api/public/vendors/:id` handler at `publicVendorRoutes.js:419` used `Vendor.findOne({ _id: id })`. When the frontend passed a slug string like `cardiff-property-partners`, Mongoose tried to cast it to ObjectId and threw.

PR #77 fixed the lookup in `publicApiRoutes.js` (mounted at `/api/v1`), but the frontend actually calls `publicVendorRoutes.js` (mounted at `/api/public`).

### Route mounts

| File | Mount path | Frontend uses? |
|------|-----------|----------------|
| `publicVendorRoutes.js` | `/api/public` | **Yes** ← broken |
| `publicApiRoutes.js` | `/api/v1` | No (fixed in PR #77) |

### Fix

3-step lookup chain replacing the single `{ _id: id }` query:

```javascript
// 1. Try ObjectId (if format matches)
if (id.match(/^[0-9a-fA-F]{24}$/)) {
  vendor = await Vendor.findOne({ _id: id, ...activeFilter }).lean();
}
// 2. Try current slug
if (!vendor) {
  vendor = await Vendor.findOne({ slug: id, ...activeFilter }).lean();
}
// 3. Try previousSlugs (for 301 redirect after slug migration)
if (!vendor) {
  vendor = await Vendor.findOne({ previousSlugs: id, ...activeFilter }).lean();
  if (vendor) redirectSlug = vendor.slug;
}
```

Returns `{ redirectSlug: 'clean-slug' }` when found via old slug so frontend can 301.

### Tests

444 passing (+3 new), 12 pre-existing failures.

### Files

- `routes/publicVendorRoutes.js` — 3-step lookup + redirectSlug response
- `tests/unit/vendorSlug.test.js` — ObjectId vs slug format detection + lookup chain test

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN)_