### PR TITLE
fix(scan): remove companyName bias from scan prompt + make Claude mod…

### DIFF
--- a/services/platformQuery/claude.js
+++ b/services/platformQuery/claude.js
@@ -9,7 +9,7 @@ export async function queryClaude({ companyName, categoryLabel, city, websiteUrl
   const prompt = buildPrompt({ companyName, categoryLabel, city });
 
   const response = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
+    model: process.env.SCAN_CLAUDE_MODEL || 'claude-haiku-4-5-20251001',
     max_tokens: 1024,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/services/platformQuery/prompt.js
+++ b/services/platformQuery/prompt.js
@@ -22,8 +22,7 @@ STRICT RULES — read carefully:
 3. Do not say "check reviews", "search online", "ask friends", "visit a directory" or any variation of this
 4. Do not name directories, comparison sites, or professional bodies (Law Society, ICAEW, etc.)
 5. Do not hedge or give generic advice — if you know businesses in this area, name them
-6. If ${companyName} is a business you would recommend, include them in your list
-7. Format your response as a numbered list: business name first, then one sentence about why
+6. Format your response as a numbered list: business name first, then one sentence about why
 
 If you genuinely do not know any specific businesses in ${city} that provide ${categoryLabel} services, respond with exactly this and nothing else:
 NO_BUSINESSES_FOUND


### PR DESCRIPTION
…el overridable

Two changes to the AI mention scan pipeline:

1. buildPrompt no longer references companyName in the prompt text. The old rule 6 ("If ${companyName} is a business you would recommend, include them") biased the visibility test by priming the model to mention the firm. Removed entirely. companyName stays in the function signature (callers still pass it) but is not injected into the prompt. The parser (parsePlatformResponse) already receives companyName separately and checks for mentions after the fact — which is the correct unbiased design.

2. Claude scan model (services/platformQuery/claude.js) is now overridable via SCAN_CLAUDE_MODEL env var, defaulting to claude-haiku-4-5-20251001 if unset. Allows model changes without a redeploy.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN