### PR TITLE
fix(scan): stop recording API failures as mentioned:false — use statu…

### DIFF
--- a/models/AIMentionScan.js
+++ b/models/AIMentionScan.js
@@ -9,11 +9,16 @@ const aiMentionScanSchema = new mongoose.Schema({
   },
   scanDate: { type: Date, default: Date.now },
   prompt: { type: String, required: true },
-  mentioned: { type: Boolean, required: true },
+  mentioned: { type: Boolean, default: null },
   position: {
     type: String,
     enum: ['first', 'top3', 'mentioned', 'not_mentioned'],
-    required: true,
+    default: 'not_mentioned',
+  },
+  status: {
+    type: String,
+    enum: ['ok', 'error', 'timeout'],
+    default: 'ok',
   },
   aiModel: { type: String, default: 'claude-haiku' },
   platform: { type: String, enum: ['chatgpt', 'perplexity', 'claude', 'gemini', 'grok', 'metaai'], default: null },
@@ -31,5 +36,6 @@ aiMentionScanSchema.index({ vendorId: 1, scanDate: -1 });
 aiMentionScanSchema.index({ scanDate: -1 });
 aiMentionScanSchema.index({ vendorId: 1, mentioned: 1, scanDate: -1 });
 aiMentionScanSchema.index({ vendorId: 1, platform: 1, mentioned: 1, scanDate: -1 });
+aiMentionScanSchema.index({ vendorId: 1, status: 1, scanDate: -1 });
 
 export default mongoose.model('AIMentionScan', aiMentionScanSchema);

--- a/routes/aiMentionRoutes.js
+++ b/routes/aiMentionRoutes.js
@@ -66,9 +66,9 @@ router.get('/summary', vendorAuth, async (req, res) => {
 
     // Paid tier gets full data
     if (paid) {
-      // Mention rate (last 30 days)
+      // Mention rate (last 30 days) — exclude error/timeout records from denominator
       const [totalPrompts, mentionedPrompts] = await Promise.all([
-        AIMentionScan.countDocuments({ vendorId, scanDate: { $gte: thirtyDaysAgo } }),
+        AIMentionScan.countDocuments({ vendorId, scanDate: { $gte: thirtyDaysAgo }, $or: [{ status: 'ok' }, { status: { $exists: false } }] }),
         AIMentionScan.countDocuments({
           vendorId,
           mentioned: true,

--- a/services/aiMentionScanner.js
+++ b/services/aiMentionScanner.js
@@ -227,26 +227,32 @@ async function scanVendor(vendor, scanDate, source = 'weekly_scan') {
 
   for (const result of platformResults) {
     const platformKey = PLATFORM_KEY_MAP[result.platform] || result.platform;
-    const mentioned = result.mentioned === true;
-    if (mentioned) mentionCount++;
+    const isError = result.status === 'error' || result.status === 'timeout';
+    const mentioned = isError ? null : result.mentioned === true;
+    if (mentioned === true) mentionCount++;
 
     mentionDocs.push({
       vendorId: vendor._id,
       scanDate,
       prompt: representativePrompt,
       mentioned,
-      position: positionToLabel(result.position, mentioned),
+      position: isError ? 'not_mentioned' : positionToLabel(result.position, mentioned),
       aiModel: result.platform,
       platform: platformKey,
-      competitorsMentioned: result.competitors || [],
+      competitorsMentioned: isError ? [] : (result.competitors || []),
       category: vendor.services?.[0] || vendorType,
       location: city,
-      responseSnippet: (result.rawResponse || result.snippet || '').substring(0, 500),
+      responseSnippet: isError
+        ? (result.error || 'Unknown error').substring(0, 500)
+        : (result.rawResponse || result.snippet || '').substring(0, 500),
       source,
+      status: result.status === 'timeout' ? 'timeout' : isError ? 'error' : 'ok',
     });
   }
 
-  console.log(`  ${vendor.company}: ${mentionCount} mentions across ${mentionDocs.length} platform queries`);
+  const errorCount = mentionDocs.filter(d => d.status !== 'ok').length;
+  const okCount = mentionDocs.length - errorCount;
+  console.log(`  ${vendor.company}: ${mentionCount} mentions across ${okCount} successful queries (${errorCount} errors)`);
   return mentionDocs;
 }
 
@@ -276,7 +282,7 @@ export async function runSingleVendorScan(vendorId) {
   // Mark first scan as complete
   await Vendor.findByIdAndUpdate(vendorId, { $set: { firstScanTriggered: true } });
 
-  const mentions = mentionDocs.filter(d => d.mentioned).length;
+  const mentions = mentionDocs.filter(d => d.mentioned === true).length;
   console.log(`[SingleScan] Complete for ${vendor.company}: ${mentionDocs.length} records, ${mentions} mentions`);
 
   return {
@@ -428,8 +434,10 @@ export async function runWeeklyMentionScan() {
   let totalMentions = 0;
   let platformErrors = 0;
   let alertsSent = 0;
+  let consecutiveVendorFailures = 0;
+  const CIRCUIT_BREAKER_THRESHOLD = 5;
   const vendorsScanned = new Set();
-  const vendorsNotified = new Set(); // Track which vendors got a mention email this cycle
+  const vendorsNotified = new Set();
 
   // Pro tier values for notification email eligibility
   const PRO_TIERS = new Set(['pro', 'managed', 'verified', 'enterprise']);
@@ -437,6 +445,12 @@ export async function runWeeklyMentionScan() {
   for (let i = 0; i < vendors.length; i++) {
     const vendor = vendors[i];
     const vendorStartTime = new Date();
+
+    if (consecutiveVendorFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+      console.error(`\n⚠️  Circuit breaker tripped: ${consecutiveVendorFailures} consecutive vendor failures. Aborting remaining ${vendors.length - i} vendors.`);
+      break;
+    }
+
     console.log(`\n[${i + 1}/${vendors.length}] Scanning ${vendor.company}...`);
 
     try {
@@ -445,9 +459,17 @@ export async function runWeeklyMentionScan() {
       if (mentionDocs.length > 0) {
         await AIMentionScan.insertMany(mentionDocs, { ordered: false });
         totalRecords += mentionDocs.length;
-        const mentions = mentionDocs.filter(d => d.mentioned);
+        const mentions = mentionDocs.filter(d => d.mentioned === true);
         totalMentions += mentions.length;
-        platformErrors += mentionDocs.filter(d => d.responseSnippet?.startsWith('API error')).length;
+        const vendorErrors = mentionDocs.filter(d => d.status !== 'ok').length;
+        platformErrors += vendorErrors;
+
+        // If ALL platforms failed for this vendor, count as a consecutive failure
+        if (vendorErrors === mentionDocs.length) {
+          consecutiveVendorFailures++;
+        } else {
+          consecutiveVendorFailures = 0;
+        }
 
         // Send email alerts for Pro vendors mentioned by any platform
         const vendorTier = (vendor.tier || '').toLowerCase();
@@ -459,12 +481,13 @@ export async function runWeeklyMentionScan() {
           vendorsNotified.add(vendorKey);
           // Send one alert for the first platform that mentioned them
           const firstMention = mentions[0];
+          const okDocs = mentionDocs.filter(d => d.status === 'ok');
           await sendMentionAlert(
             vendor,
             firstMention.platform,
             firstMention.prompt,
             mentions.length,
-            mentionDocs.length
+            okDocs.length || mentionDocs.length
           );
           alertsSent++;
         }
@@ -477,9 +500,9 @@ export async function runWeeklyMentionScan() {
 
       vendorsScanned.add(vendor._id.toString());
 
-      const completedPlatforms = mentionDocs.filter(d => !d.responseSnippet?.startsWith('API error')).length;
-      const mentionCount = mentionDocs.filter(d => d.mentioned).length;
-      const topPlatforms = mentionDocs.filter(d => d.mentioned).map(d => d.platform).filter(Boolean);
+      const completedPlatforms = mentionDocs.filter(d => d.status === 'ok').length;
+      const mentionCount = mentionDocs.filter(d => d.mentioned === true).length;
+      const topPlatforms = mentionDocs.filter(d => d.mentioned === true).map(d => d.platform).filter(Boolean);
       try {
         await AgentRun.create({
           vendorId: vendor._id,
@@ -498,6 +521,7 @@ export async function runWeeklyMentionScan() {
     } catch (err) {
       console.error(`  Failed to scan ${vendor.company}:`, err.message);
       platformErrors++;
+      consecutiveVendorFailures++;
 
       try {
         await AgentRun.create({

--- a/services/detectiveAgent.js
+++ b/services/detectiveAgent.js
@@ -38,16 +38,18 @@ export async function runDetectiveForVendor(vendorId) {
     });
   }
 
+  const okScans = scans.filter(s => s.status !== 'error' && s.status !== 'timeout');
   const platforms = {};
-  for (const s of scans) {
+  for (const s of okScans) {
     if (s.platform && !platforms[s.platform]) platforms[s.platform] = false;
-    if (s.platform && s.mentioned) platforms[s.platform] = true;
+    if (s.platform && s.mentioned === true) platforms[s.platform] = true;
   }
   const uniquePlatforms = Object.keys(platforms).length;
   const platformsCited = Object.values(platforms).filter(v => v).length;
-  const mentioned = scans.filter(s => s.mentioned).length;
-  const notMentioned = scans.filter(s => !s.mentioned).length;
-  const mentionSummary = { mentioned, notMentioned, platforms, totalScans: scans.length, platformsCited, uniquePlatforms };
+  const mentioned = okScans.filter(s => s.mentioned === true).length;
+  const notMentioned = okScans.filter(s => s.mentioned === false).length;
+  const errorCount = scans.length - okScans.length;
+  const mentionSummary = { mentioned, notMentioned, errorCount, platforms, totalScans: scans.length, platformsCited, uniquePlatforms };
 
   const competitorCounts = {};
   const competitorPlatforms = {};

--- a/services/weeklyProDigest.js
+++ b/services/weeklyProDigest.js
@@ -73,19 +73,20 @@ async function buildCitationsSection(vendorId, weekStarting, ending) {
       scanDate: { $gte: weekStarting, $lte: ending },
     }).lean();
 
+    const okScans = scans.filter(s => s.status !== 'error' && s.status !== 'timeout');
     const platforms = ['chatgpt', 'perplexity', 'claude', 'gemini', 'grok', 'metaai'];
     const byPlatform = {};
     for (const p of platforms) {
       const key = p === 'metaai' ? 'meta_ai' : p;
-      const platformScans = scans.filter(s => s.platform === p);
-      const mentioned = platformScans.filter(s => s.mentioned).length;
+      const platformScans = okScans.filter(s => s.platform === p);
+      const mentioned = platformScans.filter(s => s.mentioned === true).length;
       byPlatform[key] = { mentioned, target: platformScans.length, change: 0 };
     }
 
-    const total = scans.filter(s => s.mentioned).length;
+    const total = okScans.filter(s => s.mentioned === true).length;
 
-    const captured = scans
-      .filter(s => s.mentioned)
+    const captured = okScans
+      .filter(s => s.mentioned === true)
       .map(s => ({
         platform: s.platform === 'metaai' ? 'meta_ai' : s.platform,
         query: s.prompt || '',


### PR DESCRIPTION
…s field + circuit breaker

API failures (429s, timeouts, network errors) were being saved as mentioned:false, fabricating fake "not recommended" results that deflated mention rates. Now: error/timeout results are saved with mentioned:null + status:'error'|'timeout', and all mention-rate calculations exclude non-ok records from the denominator.

Changes:
- AIMentionScan schema: add status enum (ok/error/timeout), make mentioned nullable, add status index
- aiMentionScanner: propagate platform error status into scan records, add 5-consecutive-failure circuit breaker to batch scan
- aiMentionRoutes: exclude error records from mention-rate denominator (with backwards compat for pre-migration records via $exists check)
- detectiveAgent: filter error scans from mention/notMentioned counts
- weeklyProDigest: filter error scans from citation counts

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN