### PR TITLE
fix(comms): tell Pro firms about content drafts they need to approve

### DIFF
--- a/routes/stripeRoutes.js
+++ b/routes/stripeRoutes.js
@@ -531,6 +531,12 @@ async function handleCheckoutComplete(session) {
                     <strong>Your first AI Visibility Report</strong> arrives Monday morning &mdash; see which platforms recommend you across ChatGPT, Perplexity, Claude, Gemini, Grok, and Meta AI.
                   </td>
                 </tr>
+                <tr>
+                  <td style="padding: 12px 0; color: #7c3aed; font-weight: 600; vertical-align: top;">4.</td>
+                  <td style="padding: 12px 0; color: #374151;">
+                    <strong>Your content is being written for you.</strong> Each week we draft AI-optimised content for your firm. You review and approve it before anything publishes &mdash; nothing goes live in your name without your sign-off. Some drafts ask you to fill in a few firm-specific details (like your fees or timescales) before you can approve them. <a href="https://www.tendorai.com/vendor-dashboard/approvals" style="color: #7c3aed;">View your drafts &rarr;</a>
+                  </td>
+                </tr>
               </table>
               <div style="background: #f5f3ff; border-radius: 8px; padding: 16px; margin: 16px 0;">
                 <p style="color: #374151; margin: 0; font-size: 14px;">
@@ -543,7 +549,7 @@ async function handleCheckoutComplete(session) {
               </p>
             </div>
           `,
-          text: `Welcome to TendorAI Pro! Payment of £299/month confirmed. Step 1: Complete your profile at ${dashboardUrl}/settings. Step 2: Reply with your website login — schema installed within 48hrs. Step 3: First AI Visibility Report arrives Monday. 90-day promise — review and refund if your score isn't moving in the right direction. Questions? hello@tendorai.com`,
+          text: `Welcome to TendorAI Pro! Payment of £299/month confirmed. Step 1: Complete your profile at ${dashboardUrl}/settings. Step 2: Reply with your website login — schema installed within 48hrs. Step 3: First AI Visibility Report arrives Monday. Step 4: We draft AI-optimised content for you each week — review and approve before it publishes. Nothing goes live without your sign-off. View drafts: https://www.tendorai.com/vendor-dashboard/approvals. 90-day promise — review and refund if your score isn't moving in the right direction. Questions? hello@tendorai.com`,
           from: 'TendorAI <hello@tendorai.com>',
         });
         logger.info('Pro upgrade email sent', { vendorId: vendor._id, email: vendor.email });

--- a/services/reporter/emailBuilder.js
+++ b/services/reporter/emailBuilder.js
@@ -24,7 +24,7 @@ export function buildWeeklyEmailHTML(vendor, report) {
   }
 
   if (pendingCount > 0) {
-    bulletPoints.push(`<strong>${pendingCount}</strong> high-impact fix${pendingCount === 1 ? '' : 'es'} prepared and pending your approval`);
+    bulletPoints.push(`<strong>${pendingCount}</strong> high-impact fix${pendingCount === 1 ? '' : 'es'} prepared and pending your approval — <a href="https://www.tendorai.com/vendor-dashboard/approvals" style="color:#1a1a1a;font-weight:600">Review &amp; approve &rarr;</a>`);
   }
 
   const bulletsHtml = bulletPoints.map(b => `<li>${b}</li>`).join('\n      ');

--- a/tests/unit/writerCommsEmail.test.js
+++ b/tests/unit/writerCommsEmail.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import mongoose from 'mongoose';
+import { buildWeeklyEmailHTML } from '../../services/reporter/emailBuilder.js';
+
+const VENDOR = {
+  _id: new mongoose.Types.ObjectId(),
+  company: 'Harrison & Co',
+  location: { city: 'Cardiff' },
+};
+
+function makeReport(overrides = {}) {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    reportNumber: 'AVI-HARRISON-CO-2026-W21',
+    scoreHeader: { currentScore: 35, weeklyChange: 3 },
+    weekEndDate: new Date('2026-05-24T23:59:59.999Z'),
+    competitors: [
+      { firmName: 'Jones Law', citationCount: 5, isYou: false },
+      { firmName: 'Harrison & Co', citationCount: 2, isYou: true },
+    ],
+    recommendedActions: overrides.recommendedActions ?? [
+      { title: 'Draft: Conveyancing Costs Guide', estimatedImpact: 7 },
+      { title: 'Draft: What to Expect', estimatedImpact: 6 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Weekly Report Email — writer comms', () => {
+  it('pending-approval line includes link to approvals page', () => {
+    const html = buildWeeklyEmailHTML(VENDOR, makeReport());
+    expect(html).toContain('vendor-dashboard/approvals');
+    expect(html).toContain('Review &amp; approve');
+    expect(html).toContain('2</strong> high-impact fix');
+  });
+
+  it('links to approvals with an <a> tag', () => {
+    const html = buildWeeklyEmailHTML(VENDOR, makeReport());
+    const match = html.match(/<a[^>]*vendor-dashboard\/approvals[^>]*>/);
+    expect(match).toBeTruthy();
+  });
+
+  it('no pending-approval line when zero actions', () => {
+    const html = buildWeeklyEmailHTML(VENDOR, makeReport({ recommendedActions: [] }));
+    expect(html).not.toContain('pending your approval');
+    expect(html).not.toContain('vendor-dashboard/approvals');
+  });
+
+  it('single action uses singular "fix" not "fixes"', () => {
+    const html = buildWeeklyEmailHTML(VENDOR, makeReport({
+      recommendedActions: [{ title: 'Draft: Guide', estimatedImpact: 7 }],
+    }));
+    expect(html).toContain('1</strong> high-impact fix ');
+    expect(html).not.toContain('fixes');
+  });
+});


### PR DESCRIPTION
Writer generates content drafts that sat in the approvals queue unapproved because customers were never told the drafts existed.

Changes:
- Pro welcome email (stripeRoutes.js): added step 4 explaining the content-draft approval workflow. Frames manual approval as a benefit ("nothing goes live without your sign-off"), mentions firm-specific placeholder fields, links to /vendor-dashboard/approvals.
- Weekly report email (emailBuilder.js): the "N high-impact fixes pending your approval" bullet now includes a direct "Review & approve →" link to /vendor-dashboard/approvals.
- 4 new tests for email rendering: link present, singular/plural, zero-actions case.

Not in this branch:
- Dashboard banner showing pending approval count (frontend work)
- Writer logic or approval flow unchanged — manual approval stays

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN