### PR TITLE
Wire fabrication detector into publish guard; word-boundary fix; all …

### DIFF
--- a/scripts/prove-fabrication-guard.js
+++ b/scripts/prove-fabrication-guard.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Proves the publish guard blocks fabricated statistics across all four verticals.
+ * No DB — calls validateContentDraft directly with fixture text.
+ * Usage: node scripts/prove-fabrication-guard.js
+ */
+import { validateContentDraft } from '../services/contentPlanner/validators.js';
+
+const fabricated = {
+  solicitor: 'Law Society data shows 73% of conveyancing cases settle within 8 weeks.',
+  accountant: 'Xero analysis reveals 61% of sole traders overpay tax each year.',
+  'mortgage-adviser': 'Bank of England data shows 38% of remortgages complete late.',
+  'estate-agent': 'Propertymark data shows correctly priced homes sell 40% faster.',
+};
+
+const clean = 'Our conveyancing fees start from a fixed amount plus VAT, and most cases complete in around eight weeks.';
+
+let failures = 0;
+
+for (const [vertical, body] of Object.entries(fabricated)) {
+  const result = validateContentDraft({ body });
+  const blocked = !result.passed && result.errors.some(e => e.startsWith('Fabricated statistic'));
+  console.log(`${blocked ? 'PASS' : 'FAIL'} [${vertical}] blocked=${blocked}`);
+  if (!blocked) { failures++; console.log('   errors:', JSON.stringify(result.errors)); }
+}
+
+const cleanResult = validateContentDraft({ body: clean });
+const cleanOk = cleanResult.errors.every(e => !e.startsWith('Fabricated statistic'));
+console.log(`${cleanOk ? 'PASS' : 'FAIL'} [clean control] no false positive=${cleanOk}`);
+if (!cleanOk) { failures++; console.log('   errors:', JSON.stringify(cleanResult.errors)); }
+
+// Regression: honest sentences with substring matches must NOT be blocked
+const honestSentences = {
+  'transactions-substring': 'We handle hundreds of property transactions; data shows around 200 each year.',
+  'completions-substring': 'Our completions reports indicate we processed 150 cases last quarter.',
+};
+
+for (const [label, body] of Object.entries(honestSentences)) {
+  const result = validateContentDraft({ body });
+  const falsePositive = result.errors.some(e => e.startsWith('Fabricated statistic'));
+  const ok = !falsePositive;
+  console.log(`${ok ? 'PASS' : 'FAIL'} [${label}] not blocked=${ok}`);
+  if (!ok) { failures++; console.log('   errors:', JSON.stringify(result.errors)); }
+}
+
+console.log(failures === 0 ? '\nALL GUARDS HOLD' : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/services/contentPlanner/validators.js
+++ b/services/contentPlanner/validators.js
@@ -1,3 +1,5 @@
+import { detectPossibleFabrication } from './writerGuards.js';
+
 /**
  * Pre-publish validator for Writer Agent content drafts.
  *
@@ -147,6 +149,14 @@ export function validateContentDraft(payload) {
     warnings.push(
       `${unsourced.length} statistic(s) without a nearby Tier 1 source: ${unsourced.map(u => u.stat).slice(0, 5).join(', ')}${unsourced.length > 5 ? '...' : ''}`
     );
+  }
+
+  // Hard-block fabricated statistics attributed to a named body (Rule 20/23),
+  // across all verticals. Promotes the existing detector from a generation-time
+  // warning to a publish-blocking error.
+  const fabricated = detectPossibleFabrication(allText);
+  for (const f of fabricated) {
+    errors.push(`Fabricated statistic attributed to ${f.body}: "${f.excerpt.trim()}"`);
   }
 
   return {

--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -1,14 +1,39 @@
-const REGULATORY_BODIES = [
-  'Propertymark', 'Property Ombudsman', 'RICS', 'NAEA', 'ARLA',
-  'SRA', 'FCA', 'ICAEW', 'ACCA', 'AAT', 'ONS', 'gov\\.uk',
-  'Companies House', 'Land Registry', 'HMRC', 'CMA', 'FOS',
-  'Financial Ombudsman', 'TPO',
+// Single source of truth for every name a fabricated stat might be pinned to,
+// across all four verticals: regulators, trade press, and named software/portals.
+// detectPossibleFabrication() reads this list. Add new names here only.
+const ATTRIBUTION_SOURCES = [
+  // Cross-vertical government / stats
+  'HMRC', 'gov.uk', 'Companies House', 'ONS', 'Office for National Statistics',
+  'Bank of England', 'CMA',
+  // Solicitor
+  'SRA', 'Solicitors Regulation Authority', 'Law Society', 'Law Society Gazette',
+  'Legal Ombudsman', 'HM Land Registry', 'Land Registry', 'Conveyancing Quality Scheme',
+  'CQS', 'Legal Futures', 'Solicitors Journal', "Today's Conveyancer",
+  // Accountant
+  'ICAEW', 'ACCA', 'AAT', 'CIOT', 'Xero', 'QuickBooks', 'Sage', 'FreeAgent',
+  'AccountingWEB', 'Accountancy Age', 'Accountancy Daily', 'Economia',
+  // Mortgage adviser
+  'FCA', 'Financial Conduct Authority', 'FSCS', 'Financial Services Compensation Scheme',
+  'Financial Ombudsman Service', 'Financial Ombudsman', 'FOS', 'MCOB', 'CeMAP',
+  'Mortgage Strategy', 'FT Adviser', 'Mortgage Solutions', 'Money Marketing',
+  // Estate agent
+  'Propertymark', 'NAEA', 'ARLA', 'RICS', 'TPO', 'Property Ombudsman', 'PRS',
+  'Estate Agents Act 1979', 'Tenant Fees Act 2019',
+  'Rightmove', 'Zoopla', 'OnTheMarket',
+  'Property Industry Eye', 'Estate Agent Today', 'Letting Agent Today', 'Negotiator Magazine',
 ];
+
+// Kept under the old name for backward compatibility with existing imports/tests.
+const REGULATORY_BODIES = ATTRIBUTION_SOURCES;
 
 const DATA_VERBS = [
   'shows', 'reveals', 'analysis', 'report', 'study', 'research',
   'data', 'survey', 'found', 'indicates', 'reports',
+  'according to', 'figures', 'statistics',
 ];
+
+// Escape regex-special characters so names like "gov.uk" are treated literally.
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export function buildCtaForVendor(vendor) {
   const proTiers = new Set(['pro', 'verified', 'managed', 'enterprise']);
@@ -29,30 +54,21 @@ export function detectPossibleFabrication(draftText) {
   if (!draftText || typeof draftText !== 'string') return [];
 
   const flagged = [];
-  const verbPattern = DATA_VERBS.join('|');
-
+  const verbPattern = DATA_VERBS.map(escapeRegex).join('|');
   const numberPattern = '(\\d+[,.]?\\d*\\%?|\\d{1,3}(,\\d{3})+)';
 
-  for (const body of REGULATORY_BODIES) {
-    const cleanBody = body.replace(/\\\./g, '.');
-
-    // Pattern A: body → number → verb (e.g. "Propertymark analysis of 45,000 transactions shows")
-    const patternA = new RegExp(body + '[^.]{0,200}' + numberPattern + '[^.]{0,200}(' + verbPattern + ')', 'gi');
-    // Pattern B: body → verb → number (e.g. "RICS data indicates 73%")
-    const patternB = new RegExp(body + '[^.]{0,100}(' + verbPattern + ')[^.]{0,200}' + numberPattern, 'gi');
-    // Pattern C: verb → body → number (e.g. "According to the Property Ombudsman... 89%")
-    const patternC = new RegExp('(' + verbPattern + ')[^.]{0,100}' + body + '[^.]{0,200}' + numberPattern, 'gi');
+  for (const body of ATTRIBUTION_SOURCES) {
+    const b = '\\b' + escapeRegex(body) + '\\b';
+    const patternA = new RegExp(b + '[^.]{0,200}' + numberPattern + '[^.]{0,200}(' + verbPattern + ')', 'gi');
+    const patternB = new RegExp(b + '[^.]{0,100}(' + verbPattern + ')[^.]{0,200}' + numberPattern, 'gi');
+    const patternC = new RegExp('(' + verbPattern + ')[^.]{0,100}' + b + '[^.]{0,200}' + numberPattern, 'gi');
 
     for (const pat of [patternA, patternB, patternC]) {
       let match;
       while ((match = pat.exec(draftText)) !== null) {
         const alreadyFlagged = flagged.some(f => Math.abs(f.position - match.index) < 50);
         if (!alreadyFlagged) {
-          flagged.push({
-            body: cleanBody,
-            excerpt: match[0].substring(0, 200),
-            position: match.index,
-          });
+          flagged.push({ body, excerpt: match[0].substring(0, 200), position: match.index });
         }
       }
     }
@@ -68,4 +84,4 @@ export function countAllPlaceholderFormats(text) {
   return keyed + legacy;
 }
 
-export { REGULATORY_BODIES, DATA_VERBS };
+export { ATTRIBUTION_SOURCES, REGULATORY_BODIES, DATA_VERBS };


### PR DESCRIPTION
…4 verticals

- writerGuards.js: ATTRIBUTION_SOURCES expanded to cover all 4 verticals (solicitor, accountant, mortgage adviser, estate agent). Word boundaries added to prevent substring false positives (ONS inside "transactions", FOS inside "fostering").
- validators.js: detectPossibleFabrication now called in validateContentDraft as a hard publish-blocking error.
- prove-fabrication-guard.js: proof script, 7 checks (4 verticals blocked, clean control, 2 substring regression fixtures).

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN