### PR TITLE
Fix Writer Agent crash: missing metricsAfter on fabrication-block pat…

### DIFF
--- a/jobs/writerAgent.js
+++ b/jobs/writerAgent.js
@@ -1,5 +1,6 @@
 import cron from 'node-cron';
 import Vendor from '../models/Vendor.js';
+import AgentRun from '../models/AgentRun.js';
 import { runWriterAgentForVendor } from '../services/writerAgent.js';
 import { sendEmail } from '../services/emailService.js';
 import logger from '../services/logger.js';
@@ -55,6 +56,23 @@ export async function runWeeklyWriterAgent() {
       logger.error(`[WriterAgent] ${vendor.company}: unexpected error — ${err.message}`);
       logger.error(err.stack);
       results.push({ company: vendor.company, vendorId: String(vendor._id), success: false, error: err.message });
+
+      // Close any stuck "running" AgentRun for this vendor so it doesn't block future runs
+      try {
+        const stuckRun = await AgentRun.findOne({
+          vendorId: vendor._id, agentName: 'writer', status: 'running',
+        });
+        if (stuckRun) {
+          stuckRun.status = 'failed';
+          stuckRun.completedAt = new Date();
+          stuckRun.failureReason = `Crash recovery: ${err.message}`;
+          if (stuckRun.startedAt) stuckRun.durationMs = stuckRun.completedAt.getTime() - stuckRun.startedAt.getTime();
+          await stuckRun.save();
+          logger.warn(`[WriterAgent] Closed stuck run ${stuckRun._id} for ${vendor.company}`);
+        }
+      } catch (cleanupErr) {
+        logger.error(`[WriterAgent] Failed to close stuck run for ${vendor.company}: ${cleanupErr.message}`);
+      }
     }
 
     if (vendors.indexOf(vendor) < vendors.length - 1) {

--- a/services/agentRun.js
+++ b/services/agentRun.js
@@ -16,11 +16,30 @@ export async function createRun({ vendorId, agentName, weekStarting, summary, ar
   return run.save();
 }
 
+const STALE_RUN_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
 export async function startRun(runId) {
   const run = await AgentRun.findById(runId);
   if (!run) throw new Error('Agent run not found');
   if (run.status !== 'pending') {
     throw new Error(`Cannot start run with status "${run.status}" — must be "pending"`);
+  }
+
+  // Auto-close stale "running" records for the same vendor+agent+week
+  const stale = await AgentRun.findOne({
+    vendorId: run.vendorId,
+    agentName: run.agentName,
+    weekStarting: run.weekStarting,
+    status: 'running',
+    startedAt: { $lt: new Date(Date.now() - STALE_RUN_THRESHOLD_MS) },
+  });
+  if (stale) {
+    stale.status = 'failed';
+    stale.completedAt = new Date();
+    stale.failureReason = 'stale run auto-closed';
+    if (stale.startedAt) stale.durationMs = stale.completedAt.getTime() - stale.startedAt.getTime();
+    await stale.save();
+    console.warn(`[agentRun.startRun] Auto-closed stale run ${stale._id} (started ${stale.startedAt?.toISOString()})`);
   }
 
   run.status = 'running';
@@ -31,7 +50,9 @@ export async function startRun(runId) {
 export async function completeRun(runId, { summary, artifacts, metricsAfter, relatedApprovalIds }) {
   if (!summary) throw new Error('Summary is required to complete a run');
   if (!artifacts) throw new Error('Artifacts are required to complete a run');
-  if (!metricsAfter) throw new Error('metricsAfter is required to complete a run');
+  if (!metricsAfter) {
+    console.warn(`[agentRun.completeRun] metricsAfter missing for run ${runId} — completing with empty metrics`);
+  }
 
   const run = await AgentRun.findById(runId);
   if (!run) throw new Error('Agent run not found');
@@ -43,7 +64,7 @@ export async function completeRun(runId, { summary, artifacts, metricsAfter, rel
   run.completedAt = new Date();
   run.summary = summary;
   run.artifacts = artifacts;
-  run.metricsAfter = metricsAfter;
+  run.metricsAfter = metricsAfter || {};
   if (relatedApprovalIds) run.relatedApprovalIds = relatedApprovalIds;
   if (run.startedAt) run.durationMs = run.completedAt.getTime() - run.startedAt.getTime();
   return run.save();

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -309,6 +309,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
         postsDrafted: 0, blockedReason: 'regex_fabrication_detected',
         fabricationFlags, costEstimateUSD, model: MODEL,
       },
+      metricsAfter: { writerAgentMonthlyCostUSD: platformCostSoFar + costEstimateUSD },
     });
     console.log(`${logPrefix} ${vendor.company}: ${summary}`);
     return { success: false, blocked: true, reason: 'regex_fabrication_detected', vendorId: String(vendorId), costEstimateUSD };
@@ -346,6 +347,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
         postsDrafted: 0, blockedReason: 'llm_fabrication_review_failed',
         fabricationReview, costEstimateUSD, model: MODEL,
       },
+      metricsAfter: { writerAgentMonthlyCostUSD: platformCostSoFar + costEstimateUSD },
     });
     console.log(`${logPrefix} ${vendor.company}: ${summary}`);
     return { success: false, blocked: true, reason: 'llm_fabrication_review_failed', vendorId: String(vendorId), costEstimateUSD };

--- a/tests/unit/agentRunGuards.test.js
+++ b/tests/unit/agentRunGuards.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindById = vi.fn();
+const mockFindOne = vi.fn();
+const mockSave = vi.fn();
+
+vi.mock('../../models/AgentRun.js', () => {
+  const M = function () {};
+  M.findById = (...args) => mockFindById(...args);
+  M.findOne = (...args) => mockFindOne(...args);
+  M.normaliseWeekStarting = (d) => {
+    const date = new Date(d); const day = date.getUTCDay() || 7;
+    date.setUTCDate(date.getUTCDate() - (day - 1)); date.setUTCHours(0, 0, 0, 0); return date;
+  };
+  return { default: M };
+});
+
+const { completeRun, startRun } = await import('../../services/agentRun.js');
+
+function makeRun(overrides = {}) {
+  return {
+    _id: 'run-' + Math.random().toString(36).slice(2, 8),
+    vendorId: 'vendor-123',
+    agentName: 'writer',
+    weekStarting: new Date('2026-06-09'),
+    status: 'running',
+    startedAt: new Date(),
+    save: mockSave.mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('completeRun — metricsAfter handling', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('completes with metricsAfter present (normal path)', async () => {
+    const run = makeRun();
+    mockFindById.mockResolvedValue(run);
+    await completeRun(run._id, {
+      summary: 'test', artifacts: { foo: 1 }, metricsAfter: { cost: 0.5 },
+    });
+    expect(run.status).toBe('completed');
+    expect(run.metricsAfter).toEqual({ cost: 0.5 });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('completes with empty metrics when metricsAfter is missing (warns, does not throw)', async () => {
+    const run = makeRun();
+    mockFindById.mockResolvedValue(run);
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await completeRun(run._id, {
+      summary: 'blocked draft', artifacts: { blocked: true },
+    });
+
+    expect(run.status).toBe('completed');
+    expect(run.metricsAfter).toEqual({});
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('metricsAfter missing'));
+    spy.mockRestore();
+  });
+
+  it('still throws for missing summary', async () => {
+    await expect(completeRun('x', { artifacts: {}, metricsAfter: {} }))
+      .rejects.toThrow('Summary is required');
+  });
+
+  it('still throws for missing artifacts', async () => {
+    await expect(completeRun('x', { summary: 'x', metricsAfter: {} }))
+      .rejects.toThrow('Artifacts are required');
+  });
+});
+
+describe('startRun — stale run handling', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('auto-closes a stale running record older than 2 hours', async () => {
+    const staleRun = makeRun({
+      status: 'running',
+      startedAt: new Date(Date.now() - 3 * 60 * 60 * 1000),
+    });
+    const newRun = makeRun({ status: 'pending' });
+
+    mockFindById.mockResolvedValue(newRun);
+    mockFindOne.mockResolvedValue(staleRun);
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await startRun(newRun._id);
+
+    expect(staleRun.status).toBe('failed');
+    expect(staleRun.failureReason).toBe('stale run auto-closed');
+    expect(newRun.status).toBe('running');
+    expect(mockSave).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('does not close a recent running record (under 2 hours)', async () => {
+    const newRun = makeRun({ status: 'pending' });
+    mockFindById.mockResolvedValue(newRun);
+    mockFindOne.mockResolvedValue(null);
+
+    await startRun(newRun._id);
+    expect(newRun.status).toBe('running');
+  });
+});


### PR DESCRIPTION
…hs + defensive guards

Root cause: fabrication detector hard-block paths (regex + LLM review) called completeRun without metricsAfter, which threw and crashed the entire vendor run, leaving AgentRun stuck in "running" status.

Fixes:
1. writerAgent.js: both fabrication block paths now pass metricsAfter
2. agentRun.js completeRun: missing metricsAfter warns instead of throwing — a bookkeeping gap never crashes a run
3. jobs/writerAgent.js: catch block now closes stuck "running" AgentRun records so they don't block future runs
4. agentRun.js startRun: auto-closes stale "running" records older than 2 hours (marks failed with "stale run auto-closed")

Tests: 6 new (agentRunGuards.test.js), 30 total passing.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN