### PR TITLE
Hard org-name ban in Writer prompt + detector exempts placeholders

### DIFF
--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -56,6 +56,12 @@ export function buildCtaForVendor(vendor) {
 export function detectPossibleFabrication(draftText) {
   if (!draftText || typeof draftText !== 'string') return [];
 
+  // Strip placeholder tokens so org names inside them aren't flagged.
+  // Placeholders are declared gaps, not fabrication.
+  const text = draftText
+    .replace(/\[FIRM_DATA:[^\]]*\]/g, '___PLACEHOLDER___')
+    .replace(/\[FIRM TO PROVIDE[^\]]*\]/g, '___PLACEHOLDER___');
+
   const flagged = [];
   const verbPattern = DATA_VERBS.map(escapeRegex).join('|');
   const numberPattern = '(\\d+(?:[,.]\\d+)*(?:\\s*(?:-|–)\\s*\\d+(?:[,.]\\d+)*)?\\s*(?:%|per\\s*cent|percent|days?|weeks?|months?|years?|hours?|x\\b)?)';
@@ -68,7 +74,8 @@ export function detectPossibleFabrication(draftText) {
 
     for (const pat of [patternA, patternB, patternC]) {
       let match;
-      while ((match = pat.exec(draftText)) !== null) {
+      while ((match = pat.exec(text)) !== null) {
+        if (match[0].includes('___PLACEHOLDER___')) continue;
         const alreadyFlagged = flagged.some(f => Math.abs(f.position - match.index) < 50);
         if (!alreadyFlagged) {
           flagged.push({ body, excerpt: match[0].substring(0, 200), position: match.index });

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -20,6 +20,26 @@ const MODEL = 'claude-sonnet-4-20250514';
 
 const PRO_TIERS = new Set(['pro', 'managed', 'verified', 'enterprise']);
 
+const ORG_NAME_BAN = `## ABSOLUTE CONSTRAINT — ORGANISATION NAME BAN
+
+Do NOT mention any of the following organisations by name in the article body UNLESS the exact figure or claim being attributed to them is present verbatim in the firm_context block above:
+
+Land Registry, HM Land Registry, Propertymark, NAEA, ARLA, RICS, TPO, Property Ombudsman, PRS, Rightmove, Zoopla, OnTheMarket, SRA, Solicitors Regulation Authority, Law Society, ICAEW, ACCA, FCA, Financial Conduct Authority, HMRC, ONS, Office for National Statistics, Companies House, Bank of England, CMA, Legal Ombudsman, Financial Ombudsman, FSCS, CQS, Xero, QuickBooks, Sage, FreeAgent.
+
+This means:
+- NO "Rightmove data shows..." — unless firm_context contains that exact Rightmove figure.
+- NO "Land Registry processing times..." — unless firm_context contains that exact figure.
+- NO "NAEA research identifies..." — unless firm_context contains that exact claim.
+- NO "according to Propertymark..." — unless firm_context contains the cited figure.
+
+If you have NO data from firm_context for a claim, write from general qualitative knowledge with NO named source:
+- GOOD: "Conveyancing is typically the longest stage of a property transaction."
+- GOOD: "Accurately priced properties tend to sell faster."
+- BAD: "Land Registry data shows 8-12 weeks is typical." (fabricated attribution)
+- BAD: "Propertymark research identifies five accelerators." (fabricated attribution)
+
+This constraint is checked by an automated detector AFTER generation. Any draft containing an organisation name near a statistic not in firm_context will be automatically rejected. Emit [FIRM_DATA: ...] placeholders freely — those are correct and will NOT be flagged.`;
+
 function isProTier(tier) {
   return PRO_TIERS.has(tier);
 }
@@ -212,7 +232,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
       model: MODEL,
       max_tokens: 4000,
       temperature: 0.7,
-      system: `${SYSTEM_PROMPT_WRITER_V1_1}\n\nCURRENT_YEAR: ${new Date().getFullYear()}\n\n${firmContextBlock}`,
+      system: `${SYSTEM_PROMPT_WRITER_V1_1}\n\nCURRENT_YEAR: ${new Date().getFullYear()}\n\n${ORG_NAME_BAN}\n\n${firmContextBlock}`,
       messages: [{ role: 'user', content: cleanedPrompt }],
     });
   } catch (err) {
@@ -446,4 +466,4 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
   };
 }
 
-export { resolveNextTopic, isProTier, MONTHLY_COST_CAP_USD, MONTHLY_PER_VENDOR_CAP, SONNET_INPUT_COST_PER_M, SONNET_OUTPUT_COST_PER_M };
+export { resolveNextTopic, isProTier, MONTHLY_COST_CAP_USD, MONTHLY_PER_VENDOR_CAP, SONNET_INPUT_COST_PER_M, SONNET_OUTPUT_COST_PER_M, ORG_NAME_BAN };

--- a/tests/unit/orgNameBan.test.js
+++ b/tests/unit/orgNameBan.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { detectPossibleFabrication } from '../../services/contentPlanner/writerGuards.js';
+
+describe('detectPossibleFabrication — placeholder exemption', () => {
+  it('does NOT flag org names inside [FIRM_DATA: ...] placeholders', () => {
+    const text = 'Our fees are [FIRM_DATA: soleAgencyFeePercent | Your NAEA-registered commission rate]. We provide a quality service.';
+    const flagged = detectPossibleFabrication(text);
+    const naaeFlags = flagged.filter(f => f.body === 'NAEA');
+    expect(naaeFlags.length).toBe(0);
+  });
+
+  it('does NOT flag org names inside [FIRM TO PROVIDE: ...] placeholders', () => {
+    const text = 'Our SRA number is [FIRM TO PROVIDE: your SRA registration number with 6 digits]. We are fully regulated.';
+    const flagged = detectPossibleFabrication(text);
+    const sraFlags = flagged.filter(f => f.body === 'SRA');
+    expect(sraFlags.length).toBe(0);
+  });
+
+  it('STILL flags fabricated org attribution outside placeholders', () => {
+    const text = 'Propertymark data shows correctly priced homes sell 40% faster.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('STILL flags Rightmove fabrication', () => {
+    const text = 'Rightmove analytics indicate Cardiff properties generate 40% more enquiries.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag qualitative text with org name but no number', () => {
+    const text = 'NAEA-qualified team provides honest valuations based on local market knowledge.';
+    const flagged = detectPossibleFabrication(text);
+    expect(flagged.length).toBe(0);
+  });
+});
+
+describe('ORG_NAME_BAN prompt constant', () => {
+  it('contains all key organisation names and hard constraint language', async () => {
+    // Read the file directly to avoid the deep mongoose import chain
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    expect(content).toContain('ABSOLUTE CONSTRAINT');
+    expect(content).toContain('Do NOT mention');
+    expect(content).toContain('automatically rejected');
+    expect(content).toContain('Land Registry');
+    expect(content).toContain('Propertymark');
+    expect(content).toContain('NAEA');
+    expect(content).toContain('Rightmove');
+    expect(content).toContain('SRA');
+    expect(content).toContain('ICAEW');
+    expect(content).toContain('FCA');
+    expect(content).toContain('ONS');
+  });
+});


### PR DESCRIPTION
1. writerAgent.js: ORG_NAME_BAN injected into system prompt — lists all 30+ org names and states the model must NOT mention any by name unless the exact figure is in firm_context. Examples of good (qualitative) vs bad (fabricated attribution) given.

2. writerGuards.js detectPossibleFabrication: strips [FIRM_DATA: ...] and [FIRM TO PROVIDE: ...] tokens before scanning. Matches inside placeholder tokens are skipped. Org + stat detection unchanged.

3. Tests: 6 new — placeholder exemption, fabrication still flagged, qualitative org mention without number not flagged, prompt contains org-name ban.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN