### PR TITLE
Writer qualitative mode: no statistics without data, no body placehol…

### DIFF
--- a/routes/vendorPostRoutes.js
+++ b/routes/vendorPostRoutes.js
@@ -48,7 +48,7 @@ export function buildUserPrompt(ctx) {
     lines.push(`This topic is from the ${pillarSpec.pillarName} pillar.`);
     if (pillarSpec.tactic) lines.push(`Tactic: ${pillarSpec.tactic}`);
     if (pillarSpec.mustInclude && pillarSpec.mustInclude.length) {
-      lines.push(`Content goals (use ONLY if real data is available in firm_context; otherwise use a [FIRM_DATA] placeholder or write qualitatively — NEVER invent figures): ${pillarSpec.mustInclude.join('; ')}`);
+      lines.push(`Content goals (ONLY if the relevant data exists in firm_context — skip any goal requiring figures you don't have; write that section qualitatively instead): ${pillarSpec.mustInclude.join('; ')}`);
     }
     if (pillarSpec.wordCount) lines.push(`Word count target: ${pillarSpec.wordCount} words.`);
     if (pillarSpec.primaryAIQuery) lines.push(`Primary AI query this post targets: "${pillarSpec.primaryAIQuery}"`);
@@ -70,7 +70,7 @@ export function buildUserPrompt(ctx) {
   if (primaryData && primaryData.trim()) {
     lines.push(`The firm has provided this first-party data — weave it into the post naturally: "${primaryData.trim()}"`);
   } else if (pillarSpec && pillarSpec.primaryDataHook) {
-    lines.push(`Primary data hook — if the firm's data is in firm_context, use it. If not, emit a [FIRM_DATA] placeholder. NEVER invent figures to fill this pattern. Pattern: "${pillarSpec.primaryDataHook}"`);
+    lines.push(`Primary data hook — use this pattern ONLY if the firm's data is in firm_context. If not, skip it entirely and write the section qualitatively. NEVER invent figures. Pattern: "${pillarSpec.primaryDataHook}"`);
   }
 
   if (stats && stats.trim()) {

--- a/services/contentPlanner/fabricationReview.js
+++ b/services/contentPlanner/fabricationReview.js
@@ -1,16 +1,16 @@
 const REVIEW_MODEL = 'claude-haiku-4-5-20251001';
 
-const REVIEW_SYSTEM_PROMPT = `You are a factual accuracy reviewer for blog posts written by an AI writer agent on behalf of UK regulated professional services firms. Your job is to catch fabricated statistics, invented firm-specific claims, and false attributions.
+const REVIEW_SYSTEM_PROMPT = `You are a factual accuracy reviewer for blog posts written by an AI writer agent on behalf of UK regulated professional services firms. Your job is to catch fabricated statistics and invented claims.
 
 You receive:
 - The draft blog post text
 - The firm_context block (the ONLY verified source of firm-specific data)
 - The firm's vertical (solicitor / accountant / mortgage-advisor / estate-agent)
 
-Your task: review the draft and return a JSON object with EXACTLY this shape:
+Return a JSON object with EXACTLY this shape:
 {
   "fabricatedAttributions": [
-    { "claim": "the exact sentence or phrase", "body": "the named body it's attributed to" }
+    { "claim": "the exact sentence or phrase", "body": "the named or anonymous source" }
   ],
   "firmClaimsNotInContext": [
     { "claim": "the exact sentence or phrase" }
@@ -19,29 +19,34 @@ Your task: review the draft and return a JSON object with EXACTLY this shape:
   "verdict": "pass" | "fail"
 }
 
-Rules for flagging:
+FABRICATED ATTRIBUTIONS — flag ANY of these:
+1. A specific number, percentage, monetary value, count, or timeline attributed to a NAMED organisation (Propertymark, NAEA, RICS, Land Registry, Rightmove, SRA, ICAEW, FCA, HMRC, ONS, etc.) whose exact figure is NOT in firm_context.
+2. A specific number attributed to an ANONYMOUS source: "market data shows", "analysis indicates", "sales data suggests", "Cardiff market analysis shows", "industry research" — anonymous attribution is fabrication.
+3. Any specific statistic, percentage, or timeline that appears as factual prose but has no source in firm_context — even without an attribution phrase.
 
-FABRICATED ATTRIBUTIONS — flag ANY statistic (a specific number, percentage, monetary value, count, timeframe with a number) attributed to a named third party (regulator, trade body, portal, trade press, government source) whose EXACT figure is NOT present in the firm_context block. Examples:
-- "Propertymark data shows homes sell 40% faster" — flag unless firm_context contains this exact claim
-- "HMRC figures indicate 61% of..." — flag
-- "According to the Law Society, 73%..." — flag
-Do NOT flag: qualitative statements without specific numbers ("fees vary widely"), references to publicly known regulatory rules/thresholds (SDLT bands, SRA Transparency Rules requirements), or [FIRM_DATA: ...] placeholder tokens.
+Examples to FLAG:
+- "Propertymark data shows homes sell 40% faster" — named attribution + invented figure
+- "Cardiff market analysis shows spring generates 35% more enquiries" — anonymous attribution
+- "Chain complications account for approximately 15% of delays" — unsourced specific figure
+- "Properties typically sell within 28 days" — specific timeline not in firm_context
 
-FIRM CLAIMS NOT IN CONTEXT — flag ANY firm-specific performance claim (sales counts, completion times, success rates, fee amounts, team sizes, accreditations, awards, service areas, office addresses) that appears as a stated fact but is NOT present in the firm_context block and is NOT inside a [FIRM_DATA: ...] or [FIRM TO PROVIDE: ...] placeholder token. Examples:
-- "We sold 87 properties last year" — flag unless firm_context says so
-- "Our team of 12 qualified agents" — flag unless firm_context says so
-- "We charge 1% + VAT" — flag unless firm_context says so
-Do NOT flag [FIRM_DATA: ...] placeholders — those are correct and intentional.
+Do NOT flag:
+- Purely qualitative statements with no numbers: "overpriced properties take longer to sell"
+- Qualitative org mentions with no figure: "SRA-regulated firm", "Propertymark-registered"
+- Regulatory rules/thresholds that are public law: SDLT bands, stamp duty rates
+- [FIRM_DATA: ...] or [FIRM TO PROVIDE: ...] placeholder tokens (these are intentional, though they should not appear in the body)
 
-QUALITY SCORE — rate 0-10:
-- 10: no fabrication, no unverified claims, well-sourced
-- 8-9: minor hedging issues but no fabricated numbers
-- 5-7: some unverified claims but no attributed fabrication
-- 0-4: fabricated statistics present
+FIRM CLAIMS NOT IN CONTEXT — flag any firm-specific performance claim (sales counts, fee amounts, team sizes, accreditations, awards, specific service areas) stated as fact that is NOT in firm_context.
 
-VERDICT: "fail" if ANY fabricatedAttributions found, OR ANY firmClaimsNotInContext found, OR qualityScore < 8.5. Otherwise "pass".
+QUALITY SCORE:
+- 9-10: statistic-free qualitative content, well-written
+- 7-8: mostly qualitative with minor hedging issues
+- 4-6: contains some unsourced specific claims
+- 0-3: multiple fabricated statistics
 
-Return ONLY the JSON object. No commentary, no markdown fences, no explanation.`;
+VERDICT: "fail" if ANY fabricatedAttributions, OR ANY firmClaimsNotInContext, OR qualityScore < 8.5.
+
+Return ONLY the JSON object.`;
 
 export async function reviewDraftForFabrication({ draftText, firmContext, vertical }) {
   if (!draftText) {

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -20,25 +20,29 @@ const MODEL = 'claude-sonnet-4-20250514';
 
 const PRO_TIERS = new Set(['pro', 'managed', 'verified', 'enterprise']);
 
-const ORG_NAME_BAN = `## ABSOLUTE CONSTRAINT — ORGANISATION NAME BAN
+const ORG_NAME_BAN = `## ABSOLUTE CONSTRAINT — NO STATISTICS WITHOUT DATA
 
-Do NOT mention any of the following organisations by name in the article body UNLESS the exact figure or claim being attributed to them is present verbatim in the firm_context block above:
+The article body must contain ZERO numeric statistics, percentages, market figures, monetary amounts, or specific timelines UNLESS the exact figure appears verbatim in the firm_context block above.
 
-Land Registry, HM Land Registry, Propertymark, NAEA, ARLA, RICS, TPO, Property Ombudsman, PRS, Rightmove, Zoopla, OnTheMarket, SRA, Solicitors Regulation Authority, Law Society, ICAEW, ACCA, FCA, Financial Conduct Authority, HMRC, ONS, Office for National Statistics, Companies House, Bank of England, CMA, Legal Ombudsman, Financial Ombudsman, FSCS, CQS, Xero, QuickBooks, Sage, FreeAgent.
+This includes:
+- Named attributions: "Propertymark data shows 40%..." — BLOCKED
+- Anonymous attributions: "market data shows...", "analysis indicates...", "sales data suggests...", "Cardiff market analysis shows..." — BLOCKED (anonymous attribution is still fabrication)
+- Specific timelines: "8-12 weeks", "15 days faster" — BLOCKED unless in firm_context
+- Specific counts: "87 properties", "5 accelerators" — BLOCKED unless in firm_context
 
-This means:
-- NO "Rightmove data shows..." — unless firm_context contains that exact Rightmove figure.
-- NO "Land Registry processing times..." — unless firm_context contains that exact figure.
-- NO "NAEA research identifies..." — unless firm_context contains that exact claim.
-- NO "according to Propertymark..." — unless firm_context contains the cited figure.
+With no data in firm_context, write QUALITATIVELY with no numbers:
+- GOOD: "Overpriced properties take noticeably longer to sell."
+- GOOD: "Most residential transactions complete within a few months."
+- GOOD: "Accurately priced homes tend to attract more interest."
+- BAD: "Properties sell 40% faster when priced correctly." (invented figure)
+- BAD: "Chain complications account for approximately 15% of delays." (invented figure)
+- BAD: "Cardiff market analysis shows spring generates more enquiries." (anonymous attribution)
 
-If you have NO data from firm_context for a claim, write from general qualitative knowledge with NO named source:
-- GOOD: "Conveyancing is typically the longest stage of a property transaction."
-- GOOD: "Accurately priced properties tend to sell faster."
-- BAD: "Land Registry data shows 8-12 weeks is typical." (fabricated attribution)
-- BAD: "Propertymark research identifies five accelerators." (fabricated attribution)
+Do NOT emit [FIRM_DATA: ...] or [FIRM TO PROVIDE: ...] placeholder tokens in the article body. If data is missing, write the section qualitatively without it. Missing data keys are tracked separately as metadata — the article must read as a complete, polished piece with no visible gaps.
 
-This constraint is checked by an automated detector AFTER generation. Any draft containing an organisation name near a statistic not in firm_context will be automatically rejected. Emit [FIRM_DATA: ...] placeholders freely — those are correct and will NOT be flagged.`;
+Organisation names (Land Registry, Propertymark, NAEA, ARLA, RICS, TPO, Rightmove, Zoopla, SRA, ICAEW, FCA, HMRC, ONS, etc.) may be mentioned for qualitative context ("SRA-regulated firm", "Propertymark-registered agent") but NEVER alongside a statistic not in firm_context.
+
+This constraint is enforced by TWO automated detectors after generation. Drafts containing fabricated statistics or placeholder tokens in the body are automatically rejected.`;
 
 function isProTier(tier) {
   return PRO_TIERS.has(tier);
@@ -199,6 +203,15 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
   }
   const firmContextBlock = renderFirmContextBlock(firmContext);
 
+  // Identify which pillar-required data keys are missing from firm context
+  const dataGaps = [];
+  const firmContextStr = firmContextBlock.toLowerCase();
+  for (const [key, label] of Object.entries(FIRM_DATA_KEYS)) {
+    if (!firmContextStr.includes(key.toLowerCase()) && !firmContextStr.includes(label.toLowerCase().split('(')[0].trim())) {
+      dataGaps.push(key);
+    }
+  }
+
   const cta = buildCtaForVendor(vendor);
   const userPrompt = buildUserPrompt({
     topic: topicTitle,
@@ -212,7 +225,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
     linkedInHookType: next.topic.linkedInHookType || 'opinion',
     ctaUrl: cta.ctaUrl,
     ctaText: cta.ctaText,
-    allowedFirmDataKeys: FIRM_DATA_KEYS,
+    allowedFirmDataKeys: {},
   });
 
   // Strip unfilled template patterns from the prompt so the model never sees
@@ -423,6 +436,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
       topicSuitabilityFlag,
       agentReportedPlaceholderCount,
       qualityScore: fabricationReview.qualityScore,
+      dataGaps: dataGaps.length > 0 ? dataGaps : undefined,
       ...(dryRun ? { dryRun: true } : {}),
     },
     source: 'writer-agent-cron',

--- a/tests/unit/orgNameBan.test.js
+++ b/tests/unit/orgNameBan.test.js
@@ -41,7 +41,6 @@ describe('ORG_NAME_BAN prompt constant', () => {
     const fs = await import('fs');
     const content = fs.readFileSync('services/writerAgent.js', 'utf8');
     expect(content).toContain('ABSOLUTE CONSTRAINT');
-    expect(content).toContain('Do NOT mention');
     expect(content).toContain('automatically rejected');
     expect(content).toContain('Land Registry');
     expect(content).toContain('Propertymark');

--- a/tests/unit/qualitativeMode.test.js
+++ b/tests/unit/qualitativeMode.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { validateContentDraft } from '../../services/contentPlanner/validators.js';
+
+describe('Qualitative mode — no statistics, no placeholders in body', () => {
+  it('prompt contains the absolute statistics ban', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    expect(content).toContain('ZERO numeric statistics');
+    expect(content).toContain('anonymous attribution is still fabrication');
+    expect(content).toContain('Do NOT emit [FIRM_DATA');
+    expect(content).toContain('write QUALITATIVELY');
+  });
+
+  it('prompt no longer passes allowedFirmDataKeys to the model', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    expect(content).toContain("allowedFirmDataKeys: {},");
+  });
+
+  it('draft body containing [FIRM_DATA: ...] fails validation', () => {
+    const result = validateContentDraft({
+      body: 'Our fees start from [FIRM_DATA: soleAgencyFeePercent | Your commission rate] plus VAT.',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.errors.some(e => e.includes('placeholder'))).toBe(true);
+  });
+
+  it('qualitative body with no statistics passes validation', () => {
+    const result = validateContentDraft({
+      body: 'Overpriced properties take noticeably longer to sell. Most residential transactions in Cardiff complete within a few months. Accurate initial pricing attracts more buyer interest and typically leads to a smoother process.',
+    });
+    const fabricationErrors = result.errors.filter(e => e.includes('Fabricated'));
+    expect(fabricationErrors.length).toBe(0);
+  });
+
+  it('dataGaps field exists in writerAgent approval metadata logic', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    expect(content).toContain('dataGaps:');
+    expect(content).toContain('dataGaps.length');
+  });
+
+  it('LLM reviewer prompt flags anonymous attribution', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/contentPlanner/fabricationReview.js', 'utf8');
+    expect(content).toContain('anonymous attribution is fabrication');
+    expect(content).toContain('Cardiff market analysis shows');
+  });
+});


### PR DESCRIPTION
…ders, data gaps as metadata

When firm_context lacks data, the article is now fully qualitative — no statistics, no percentages, no specific timelines, no placeholders in the body. Data gaps are tracked as metadata on the approval record.

Changes:
1. writerAgent.js ORG_NAME_BAN: rewritten as absolute statistics ban. Bans named AND anonymous attributions ("market data shows...", "analysis indicates..."). Bans [FIRM_DATA] tokens in body. Instructs qualitative writing when no data available.
2. writerAgent.js: dataGaps[] computed from FIRM_DATA_KEYS vs firmContext; stored on approval metadata. allowedFirmDataKeys no longer passed to prompt (no placeholder emission).
3. fabricationReview.js: LLM reviewer prompt updated to flag anonymous attributions and unsourced specific figures. Aligned with the no-statistics standard.
4. vendorPostRoutes.js buildUserPrompt: mustInclude qualified as "skip if data unavailable"; primaryDataHook says "skip entirely if not in firm_context".
5. orgNameBan.test.js: updated assertion for rewritten prompt.

Tests: 6 new (qualitativeMode.test.js), 27 total passing.
Proof script: 7/7 checks pass. Detectors at full strength.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN