### PR TITLE
Fix firmData contract: dataGaps as { key, label }, stored on draftPay…

### DIFF
--- a/routes/vendorApprovalRoutes.js
+++ b/routes/vendorApprovalRoutes.js
@@ -112,6 +112,18 @@ router.post('/:id/firm-data', async (req, res) => {
     if (approval.draftPayload?.facebookText) {
       approval.draftPayload.facebookText = approval.draftPayload.facebookText.replace(keyPattern, String(value));
     }
+    // Remove saved key from dataGaps so it disappears on refresh
+    if (Array.isArray(approval.draftPayload?.dataGaps)) {
+      approval.draftPayload.dataGaps = approval.draftPayload.dataGaps.filter(g =>
+        typeof g === 'string' ? g !== key : g?.key !== key
+      );
+    }
+    if (Array.isArray(approval.metadata?.dataGaps)) {
+      approval.metadata.dataGaps = approval.metadata.dataGaps.filter(g =>
+        typeof g === 'string' ? g !== key : g?.key !== key
+      );
+      approval.markModified('metadata');
+    }
     approval.markModified('draftPayload');
     await approval.save();
 

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -208,7 +208,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
   const firmContextStr = firmContextBlock.toLowerCase();
   for (const [key, label] of Object.entries(FIRM_DATA_KEYS)) {
     if (!firmContextStr.includes(key.toLowerCase()) && !firmContextStr.includes(label.toLowerCase().split('(')[0].trim())) {
-      dataGaps.push(key);
+      dataGaps.push({ key, label });
     }
   }
 
@@ -547,6 +547,7 @@ export async function runWriterAgentForVendor(vendorId, options = {}) {
       tags: [next.pillarId, vendor.vendorType, vendor.location?.city?.toLowerCase()].filter(Boolean),
       placeholderCount: verifiedPlaceholderCount,
       topicSuitabilityFlag,
+      dataGaps: dataGaps.length > 0 ? dataGaps : [],
     },
     metadata: {
       agentRunId: agentRun._id,

--- a/tests/unit/firmDataContract.test.js
+++ b/tests/unit/firmDataContract.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+describe('firmData contract verification', () => {
+  it('writerAgent emits dataGaps as { key, label } objects, not plain strings', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    expect(content).toContain("dataGaps.push({ key, label })");
+  });
+
+  it('dataGaps is stored on draftPayload (accessible to frontend without metadata dig)', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('services/writerAgent.js', 'utf8');
+    // Should appear in the draftPayload block, not just metadata
+    const draftPayloadSection = content.slice(
+      content.indexOf('draftPayload: {'),
+      content.indexOf('metadata: {')
+    );
+    expect(draftPayloadSection).toContain('dataGaps:');
+  });
+
+  it('firm-data endpoint removes saved key from draftPayload.dataGaps', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('routes/vendorApprovalRoutes.js', 'utf8');
+    expect(content).toContain('draftPayload.dataGaps');
+    expect(content).toContain('.filter(g =>');
+    expect(content).toContain("g?.key !== key");
+  });
+
+  it('firm-data endpoint also removes from metadata.dataGaps', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('routes/vendorApprovalRoutes.js', 'utf8');
+    expect(content).toContain('metadata.dataGaps');
+    expect(content).toContain("markModified('metadata')");
+  });
+
+  it('FIRM_DATA_KEYS registry is the single source of truth for gap keys', async () => {
+    const fs = await import('fs');
+    const writerContent = fs.readFileSync('services/writerAgent.js', 'utf8');
+    const routeContent = fs.readFileSync('routes/vendorApprovalRoutes.js', 'utf8');
+    // Writer iterates FIRM_DATA_KEYS for gaps
+    expect(writerContent).toContain('Object.entries(FIRM_DATA_KEYS)');
+    // Route validates against isValidFirmDataKey
+    expect(routeContent).toContain('isValidFirmDataKey(key)');
+  });
+});


### PR DESCRIPTION
…load, removed on save

Findings from contract audit:
1. dataGaps was string[] (just keys) — changed to { key, label }[] so frontend can show human-readable prompts without a lookup.
2. dataGaps was only in metadata — now also on draftPayload for direct frontend access.
3. Saving firm data did NOT remove the key from dataGaps — gap persisted on refresh. Now removes from both draftPayload.dataGaps and metadata.dataGaps on save.
4. Writer already skips populated keys via firmContext substring check (wired, fragile but functional).

Contract: frontend reads approval.draftPayload.dataGaps as [{ key, label }], saves via POST /api/vendor/approvals/:id/firm-data with { key, value }, key disappears from dataGaps on refresh.

Tests: 5 new (firmDataContract.test.js).

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN