### PR TITLE
Fix article publish pipeline: executed drafts now go live as 'published'

### DIFF
--- a/routes/adminApprovalRoutes.js
+++ b/routes/adminApprovalRoutes.js
@@ -77,7 +77,7 @@ router.post('/:id/execute', async (req, res) => {
 
     let liveUrl = null;
     if (item.itemType === 'content_draft' && item.executionResult?.slug) {
-      liveUrl = `https://tendorai.com/resources/${item.executionResult.slug}`;
+      liveUrl = `https://www.tendorai.com/posts/${item.executionResult.slug}`;
       item.liveUrl = liveUrl;
       await item.save();
       pingBingIndexNow([liveUrl]).then(result => {

--- a/routes/vendorPostRoutes.js
+++ b/routes/vendorPostRoutes.js
@@ -450,6 +450,33 @@ router.put('/:vendorId/posts/:postId/hide', vendorAuth, async (req, res) => {
   }
 });
 
+// GET /api/posts/sitemap.xml — sitemap of all published posts for crawlers
+router.get('/sitemap.xml', async (req, res) => {
+  try {
+    const posts = await VendorPost.find({ status: 'published' })
+      .select('slug updatedAt')
+      .sort({ updatedAt: -1 })
+      .lean();
+
+    const baseUrl = 'https://www.tendorai.com';
+    const urls = posts.map(p => `  <url>
+    <loc>${baseUrl}/posts/${p.slug}</loc>
+    <lastmod>${(p.updatedAt || new Date()).toISOString().split('T')[0]}</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>`).join('\n');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+
+    res.set('Content-Type', 'application/xml');
+    res.send(xml);
+  } catch (error) {
+    res.status(500).send('<?xml version="1.0"?><urlset/>');
+  }
+});
+
 // GET /api/posts/feed — all published posts across vendors (public, for GEO crawling)
 router.get('/feed', async (req, res) => {
   try {

--- a/services/approvalQueue.js
+++ b/services/approvalQueue.js
@@ -76,7 +76,7 @@ const executionHandlers = {
       body: payload.body,
       category: payload.category || 'guide',
       tags: payload.tags || [],
-      status: 'draft',
+      status: 'published',
       aiGenerated: true,
       topic: payload.topic,
       stats: payload.stats,


### PR DESCRIPTION
Root cause: execute handler created VendorPosts with status 'draft' but all public surfaces filter on 'published'. Articles existed in the DB but were invisible to the API, profile page, and crawlers.

Changes:
1. approvalQueue.js: VendorPost status changed from 'draft' to 'published'. validateContentDraft still runs before creation (publish guard intact — placeholders, fabrication, banned phrases all block before this line).
2. adminApprovalRoutes.js: liveUrl changed from non-existent /resources/ path to /posts/${slug}, matching the real public endpoint (GET /api/posts/:slug with BlogPosting JSON-LD).
3. vendorPostRoutes.js: added GET /api/posts/sitemap.xml returning an XML sitemap of all published posts for crawler discovery (loc, lastmod, monthly changefreq).

Verified: GET /api/public/vendors/:vendorId/posts already filters on published and returns all fields the frontend needs (title, slug, body, category, tags, createdAt). No change needed.

Existing infrastructure unchanged:
- IndexNow ping fires on execute (already wired)
- BlogPosting JSON-LD served by GET /api/posts/:slug (already wired)
- Posts feed at GET /api/posts/feed (already wired)

Frontend work needed (separate repo):
- /posts/[slug] page with SSR + JSON-LD in <head>
- Vendor profile articles section calling the posts API
- robots.txt/sitemap index inclusion

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN