### PR TITLE
Fix publish guard false positives: sentence-scoped performance claim …

### DIFF
--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -115,25 +115,35 @@ const PLACEHOLDER_FENCE = /\[FIRM_DATA:[^\]]+\]|\[FIRM TO PROVIDE[^\]]*\]/g;
 export function detectFirmPerformanceClaims(draftText, firmName) {
   if (!draftText || typeof draftText !== 'string') return [];
 
-  const stripped = draftText.replace(PLACEHOLDER_FENCE, '___PLACEHOLDER___');
+  // Strip placeholders and legislation so they don't trigger false positives
+  const stripped = draftText
+    .replace(PLACEHOLDER_FENCE, '___PLACEHOLDER___')
+    .replace(LEGISLATION_PATTERN, '___LEGISLATION___');
+
   const flagged = [];
-  const numPat = /\d+(?:[,.]?\d+)*\s*%?/g;
-  let numMatch;
 
-  while ((numMatch = numPat.exec(stripped)) !== null) {
-    const pos = numMatch.index;
-    const windowStart = Math.max(0, pos - 60);
-    const windowEnd = Math.min(stripped.length, pos + numMatch[0].length + 60);
-    const window = stripped.slice(windowStart, windowEnd).toLowerCase();
+  // Split into sentences and check each independently
+  const sentences = stripped.split(/(?<=[.!?])\s+/);
+  for (const sentence of sentences) {
+    if (sentence.includes('___PLACEHOLDER___')) continue;
+    if (sentence.includes('___LEGISLATION___')) continue;
 
-    if (window.includes('___placeholder___')) continue;
+    // Must contain a number (not just a list marker like "1.")
+    const hasNumber = /\d{2,}|\d+\s*%|\d+\s+(?:properties|transactions|cases|clients|days|weeks|months|hours)/.test(sentence);
+    if (!hasNumber) continue;
 
-    const hasPerformanceNoun = PERFORMANCE_NOUNS.some(n => window.includes(n));
+    // Check for whole-word performance nouns
+    const lower = sentence.toLowerCase();
+    const hasPerformanceNoun = PERFORMANCE_NOUNS.some(n => {
+      const re = new RegExp('\\b' + n + '\\b', 'i');
+      return re.test(lower);
+    });
+
     if (hasPerformanceNoun) {
       flagged.push({
         type: 'firm_performance_claim',
-        excerpt: stripped.slice(windowStart, windowEnd).trim(),
-        position: pos,
+        excerpt: sentence.trim().substring(0, 200),
+        position: stripped.indexOf(sentence),
       });
     }
   }

--- a/tests/unit/publishGuardRegex.test.js
+++ b/tests/unit/publishGuardRegex.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { detectFirmPerformanceClaims } from '../../services/contentPlanner/writerGuards.js';
+
+describe('detectFirmPerformanceClaims — false positive fixes', () => {
+  it('does NOT flag mid-word boundary fragments like "rtners is registered with Propertymark"', () => {
+    const text = 'Cardiff Property Partners is registered with Propertymark and provides professional estate agency services across the city.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length, `Should not flag: ${JSON.stringify(flagged)}`).toBe(0);
+  });
+
+  it('does NOT flag "uyer exposure throughout Cardiff"', () => {
+    const text = 'Our marketing strategy maximises buyer exposure throughout Cardiff and the surrounding Vale of Glamorgan area.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag legislation with year: "Estate Agents Act 1979"', () => {
+    const text = 'Under the Estate Agents Act 1979, all practising agents must join an approved redress scheme. Sales proceed under these regulations.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag numbered list items like "1. Accurate pricing"', () => {
+    const text = '1. Accurate pricing attracts more buyer interest.\n2. Professional photography improves sales outcomes.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag placeholder tokens', () => {
+    const text = 'We sold [FIRM_DATA: propertiesSoldThisYear | Number of properties sold] properties last year.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+});
+
+describe('detectFirmPerformanceClaims — true positives still blocked', () => {
+  it('STILL flags "sold 87 properties"', () => {
+    const text = 'Cardiff Property Partners sold 87 properties in the last year.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('STILL flags "achieved 98% across 87 transactions"', () => {
+    const text = 'We achieved 98% of asking prices across 87 transactions.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('STILL flags "completed 150 cases"', () => {
+    const text = 'Our team completed 150 cases last quarter with an average turnaround of 28 days.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
…detection

detectFirmPerformanceClaims was matching mid-word, cross-boundary fragments ("rtners is registered with Propertymark", "uyer exposure throughout Cardiff") because:
- 60-char window around ANY number grabbed adjacent sentences
- PERFORMANCE_NOUNS matched as substrings inside words
- Legislation years (1979) triggered the number pattern

Fix — same approach as the fabrication detector fix:
- Split into sentences, check each independently
- Strip placeholders and legislation before scanning
- Require whole-word match for performance nouns (\b boundary)
- Require numbers of 2+ digits or number + unit (not list markers)

Since validators.js imports directly from writerGuards.js, the publish guard and generation-time detector are the SAME function — they cannot drift apart. No separate copy to maintain.

True positives preserved: "sold 87 properties", "achieved 98% across 87 transactions", "completed 150 cases" all still blocked.

Tests: 8 new (publishGuardRegex.test.js), 41 total passing.
Proof script: 7/7 checks pass.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN