### PR TITLE
Fix perf-claims detector: skip markdown structure, require firm voice

### DIFF
--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -122,30 +122,55 @@ export function detectFirmPerformanceClaims(draftText, firmName) {
 
   const flagged = [];
 
-  // Split into sentences and check each independently
-  const sentences = stripped.split(/(?<=[.!?])\s+/);
-  for (const sentence of sentences) {
-    if (sentence.includes('___PLACEHOLDER___')) continue;
-    if (sentence.includes('___LEGISLATION___')) continue;
+  // Split on sentence boundaries AND markdown structure (bullets, table rows, headings, newlines)
+  const segments = stripped.split(/(?<=[.!?])\s+|\n+/).filter(s => s.trim());
+
+  // First-person / firm-specific indicators — a real firm performance claim
+  // attributes a figure to the firm itself, not generic industry info
+  const FIRM_INDICATORS = /\b(?:we|our|us|the firm|the team|the company)\b/i;
+
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    const clean = trimmed.replace(/^[-*•|#>\s]+/, '').trim();
+    if (!clean) continue;
+    if (clean.includes('___PLACEHOLDER___')) continue;
+    if (clean.includes('___LEGISLATION___')) continue;
+
+    // Skip markdown headings — structural, not assertions
+    if (/^#{1,6}\s/.test(trimmed)) continue;
+
+    // Skip table header/separator rows and generic table content
+    if (/^\|[-\s|]+\|$/.test(trimmed)) continue;
+    if (/^\|/.test(trimmed)) continue;
 
     // Must contain a number (not just a list marker like "1.")
-    const hasNumber = /\d{2,}|\d+\s*%|\d+\s+(?:properties|transactions|cases|clients|days|weeks|months|hours)/.test(sentence);
+    const hasNumber = /\d{2,}|\d+\s*%/.test(clean);
     if (!hasNumber) continue;
 
-    // Check for whole-word performance nouns
-    const lower = sentence.toLowerCase();
+    // Must contain a whole-word performance noun
+    const lower = clean.toLowerCase();
     const hasPerformanceNoun = PERFORMANCE_NOUNS.some(n => {
       const re = new RegExp('\\b' + n + '\\b', 'i');
       return re.test(lower);
     });
+    if (!hasPerformanceNoun) continue;
 
-    if (hasPerformanceNoun) {
-      flagged.push({
-        type: 'firm_performance_claim',
-        excerpt: sentence.trim().substring(0, 200),
-        position: stripped.indexOf(sentence),
-      });
-    }
+    // Only flag if it reads as a FIRM-SPECIFIC claim:
+    // - First-person/possessive ("we sold", "our team completed")
+    // - Past-tense performance verb as if reporting the firm's results
+    //   ("sold 87 properties" — article is published as the firm's voice)
+    // NOT generic process description ("sales typically take 4-8 weeks")
+    const hasFirmVoice = FIRM_INDICATORS.test(clean);
+    const hasGenericHedge = /\b(?:typically|usually|generally|on average|average|often|most|many|standard|normal|common)\b/i.test(clean);
+
+    if (!hasFirmVoice && hasGenericHedge) continue;
+    if (!hasFirmVoice && /^\|/.test(segment.trim())) continue; // table row without firm voice
+
+    flagged.push({
+      type: 'firm_performance_claim',
+      excerpt: clean.substring(0, 200),
+      position: stripped.indexOf(segment),
+    });
   }
 
   return flagged;

--- a/tests/unit/publishGuardRegex.test.js
+++ b/tests/unit/publishGuardRegex.test.js
@@ -31,6 +31,24 @@ describe('detectFirmPerformanceClaims — false positive fixes', () => {
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBe(0);
   });
+
+  it('does NOT flag bulleted list with generic process info (Case 1: "comparable sales data")', () => {
+    const text = '- **Property valuation stage**: Estate agents assess market value using comparable sales data and current market conditions in Cardiff\n- **Marketing preparation**: Professional photography, floorplans, and 12 portal listings prepared within 48 hours';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length, `Should not flag generic process bullets: ${JSON.stringify(flagged)}`).toBe(0);
+  });
+
+  it('does NOT flag markdown table with generic timeframes (Case 2: "1-2 weeks")', () => {
+    const text = '## Cardiff Property Sales Timeframes in 2026\n| Stage | Typical Duration | Key Activities |\n|-------|------------------|----------------|\n| Valuation to marketing | 1-2 weeks | Photography, EPC, floorplan |\n| On market to offer | 4-8 weeks | Viewings, negotiations |\n| Offer to exchange | 6-10 weeks | Surveys, searches, mortgage |';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length, `Should not flag generic table: ${JSON.stringify(flagged)}`).toBe(0);
+  });
+
+  it('does NOT flag generic industry prose with "sales typically take"', () => {
+    const text = 'Property sales typically take 12-16 weeks from instruction to completion in Cardiff.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
 });
 
 describe('detectFirmPerformanceClaims — true positives still blocked', () => {


### PR DESCRIPTION
Production false positives:
- Bulleted list "comparable sales data" flagged (generic process)
- Table "1-2 weeks typical duration" flagged (generic timeframe)
- Heading "Cardiff Property Sales Timeframes in 2026" flagged

Root causes:
1. Sentence split didn't split on newlines/markdown — bullets and table rows lumped together
2. No firm-voice gate — generic industry process info was flagged the same as "we sold 87 properties"

Fix:
- Split on newlines AND sentence boundaries (not just .!?)
- Skip markdown headings (# lines) — structural, not assertions
- Skip all table rows (| lines)
- Require firm-voice indicator (we/our/us/the firm/the team) OR absence of generic hedge words (typically/usually/on average)
- Generic hedged prose + number = not a firm claim, passes

True positives preserved:
- "We achieved 98% across 87 transactions" — has "We" → flagged
- "Our team completed 150 cases" — has "Our" → flagged
- "Cardiff Property Partners sold 87 properties" — no generic hedge, not a table/heading → flagged

Tests: 44 total (3 new fixtures added), 7/7 proof checks pass.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN