### PR TITLE
Fix perf-claims: subject-based gate, markdown structure, expanded nou…

### DIFF
--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -105,12 +105,20 @@ export function countAllPlaceholderFormats(text) {
 }
 
 const PERFORMANCE_NOUNS = [
-  'sold', 'completed', 'achieved', 'handled', 'processed', 'managed',
-  'transactions', 'properties', 'cases', 'clients', 'instructions',
-  'completions', 'sales', 'lettings', 'exchanges',
+  'sold', 'sell', 'selling', 'completed', 'completing', 'completion',
+  'achieved', 'achieving', 'handled', 'handling', 'processed', 'processing',
+  'managed', 'managing', 'transactions', 'transaction', 'properties', 'property',
+  'cases', 'clients', 'instructions', 'completions',
+  'sales', 'lettings', 'letting', 'exchanges', 'exchange',
 ];
 
 const PLACEHOLDER_FENCE = /\[FIRM_DATA:[^\]]+\]|\[FIRM TO PROVIDE[^\]]*\]/g;
+
+// Firm-subject indicators — the claim is attributed to THIS firm
+const FIRM_SUBJECT = /\b(?:we|our|us|the firm|the team|the company)\b/i;
+
+// Generic-industry subjects — the claim is about the market/process, not the firm
+const GENERIC_SUBJECT = /\b(?:sales|conveyancing|transactions?|properties|the (?:average|typical|standard)|most|many|an? average)\b.*\b(?:typically|usually|generally|often|on average|normally|commonly|tend to|can take|range from)\b/i;
 
 export function detectFirmPerformanceClaims(draftText, firmName) {
   if (!draftText || typeof draftText !== 'string') return [];
@@ -122,30 +130,46 @@ export function detectFirmPerformanceClaims(draftText, firmName) {
 
   const flagged = [];
 
-  // Split into sentences and check each independently
-  const sentences = stripped.split(/(?<=[.!?])\s+/);
-  for (const sentence of sentences) {
-    if (sentence.includes('___PLACEHOLDER___')) continue;
-    if (sentence.includes('___LEGISLATION___')) continue;
+  // Split on sentence boundaries AND markdown structure
+  const segments = stripped.split(/(?<=[.!?])\s+|\n+/).filter(s => s.trim());
 
-    // Must contain a number (not just a list marker like "1.")
-    const hasNumber = /\d{2,}|\d+\s*%|\d+\s+(?:properties|transactions|cases|clients|days|weeks|months|hours)/.test(sentence);
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    const clean = trimmed.replace(/^[-*•|#>\s]+/, '').trim();
+    if (!clean) continue;
+    if (clean.includes('___PLACEHOLDER___')) continue;
+    if (clean.includes('___LEGISLATION___')) continue;
+
+    // Skip markdown headings and table rows — structural, not assertions
+    if (/^#{1,6}\s/.test(trimmed)) continue;
+    if (/^\|/.test(trimmed)) continue;
+
+    // Must contain a meaningful number (not a list marker)
+    const hasNumber = /\d{2,}|\d+\s*%/.test(clean);
     if (!hasNumber) continue;
 
-    // Check for whole-word performance nouns
-    const lower = sentence.toLowerCase();
+    // Must contain a whole-word performance noun
     const hasPerformanceNoun = PERFORMANCE_NOUNS.some(n => {
       const re = new RegExp('\\b' + n + '\\b', 'i');
-      return re.test(lower);
+      return re.test(clean);
     });
+    if (!hasPerformanceNoun) continue;
 
-    if (hasPerformanceNoun) {
-      flagged.push({
-        type: 'firm_performance_claim',
-        excerpt: sentence.trim().substring(0, 200),
-        position: stripped.indexOf(sentence),
-      });
-    }
+    // Subject gate: is the claim attributed to the firm or to the generic industry?
+    const hasFirmSubject = FIRM_SUBJECT.test(clean);
+    const hasGenericSubject = GENERIC_SUBJECT.test(clean);
+
+    // If the subject is clearly generic industry ("sales typically take 4-8 weeks"), pass
+    if (hasGenericSubject && !hasFirmSubject) continue;
+
+    // If the subject is the firm ("we sold 87", "our average is 10 weeks"), flag
+    // If ambiguous (no clear subject either way), flag — the article is published
+    // in the firm's voice, so an unattributed claim defaults to the firm
+    flagged.push({
+      type: 'firm_performance_claim',
+      excerpt: clean.substring(0, 200),
+      position: stripped.indexOf(segment),
+    });
   }
 
   return flagged;

--- a/tests/unit/publishGuardRegex.test.js
+++ b/tests/unit/publishGuardRegex.test.js
@@ -1,26 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import { detectFirmPerformanceClaims } from '../../services/contentPlanner/writerGuards.js';
 
-describe('detectFirmPerformanceClaims — false positive fixes', () => {
-  it('does NOT flag mid-word boundary fragments like "rtners is registered with Propertymark"', () => {
+describe('detectFirmPerformanceClaims — false positives (must pass)', () => {
+  it('does NOT flag mid-word boundary fragments', () => {
     const text = 'Cardiff Property Partners is registered with Propertymark and provides professional estate agency services across the city.';
     const flagged = detectFirmPerformanceClaims(text);
-    expect(flagged.length, `Should not flag: ${JSON.stringify(flagged)}`).toBe(0);
+    expect(flagged.length).toBe(0);
   });
 
-  it('does NOT flag "uyer exposure throughout Cardiff"', () => {
+  it('does NOT flag generic marketing text', () => {
     const text = 'Our marketing strategy maximises buyer exposure throughout Cardiff and the surrounding Vale of Glamorgan area.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBe(0);
   });
 
-  it('does NOT flag legislation with year: "Estate Agents Act 1979"', () => {
-    const text = 'Under the Estate Agents Act 1979, all practising agents must join an approved redress scheme. Sales proceed under these regulations.';
+  it('does NOT flag legislation: "Estate Agents Act 1979"', () => {
+    const text = 'Under the Estate Agents Act 1979, all practising agents must join an approved redress scheme.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBe(0);
   });
 
-  it('does NOT flag numbered list items like "1. Accurate pricing"', () => {
+  it('does NOT flag numbered list items', () => {
     const text = '1. Accurate pricing attracts more buyer interest.\n2. Professional photography improves sales outcomes.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBe(0);
@@ -31,23 +31,59 @@ describe('detectFirmPerformanceClaims — false positive fixes', () => {
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBe(0);
   });
+
+  it('does NOT flag bulleted list with generic process info', () => {
+    const text = '- **Property valuation stage**: Estate agents assess market value using comparable sales data and current market conditions in Cardiff\n- **Marketing preparation**: Professional photography, floorplans, and 12 portal listings prepared within 48 hours';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag markdown table with generic timeframes', () => {
+    const text = '## Cardiff Property Sales Timeframes in 2026\n| Stage | Typical Duration | Key Activities |\n|-------|------------------|----------------|\n| Valuation to marketing | 1-2 weeks | Photography, EPC |\n| On market to offer | 4-8 weeks | Viewings |';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag generic industry prose: "Sales typically take 4-8 weeks in Cardiff"', () => {
+    const text = 'Sales typically take 4-8 weeks in Cardiff depending on market conditions.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
+
+  it('does NOT flag "The average Cardiff sale completes in 3-6 months"', () => {
+    const text = 'The average Cardiff sale completes in 3-6 months from instruction to keys.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBe(0);
+  });
 });
 
-describe('detectFirmPerformanceClaims — true positives still blocked', () => {
-  it('STILL flags "sold 87 properties"', () => {
+describe('detectFirmPerformanceClaims — true positives (must flag)', () => {
+  it('flags "Cardiff Property Partners sold 87 properties last year"', () => {
     const text = 'Cardiff Property Partners sold 87 properties in the last year.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBeGreaterThan(0);
   });
 
-  it('STILL flags "achieved 98% across 87 transactions"', () => {
+  it('flags "We achieved 98% across 87 transactions"', () => {
     const text = 'We achieved 98% of asking prices across 87 transactions.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBeGreaterThan(0);
   });
 
-  it('STILL flags "completed 150 cases"', () => {
+  it('flags "Our team completed 150 cases"', () => {
     const text = 'Our team completed 150 cases last quarter with an average turnaround of 28 days.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('flags hedged firm claim: "We typically sell homes in 18 days"', () => {
+    const text = 'We typically sell homes in 18 days.';
+    const flagged = detectFirmPerformanceClaims(text);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('flags hedged firm claim: "Our average completion time is 10 weeks"', () => {
+    const text = 'Our average completion time is 10 weeks.';
     const flagged = detectFirmPerformanceClaims(text);
     expect(flagged.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
…n list

Replaced hedge-word exemption with subject-based gate:
- FIRM subject (we/our/us/the firm/the team) → always flag
- GENERIC subject (sales typically take, the average Cardiff sale) → pass, not a firm claim
- Ambiguous (no clear subject) → flag (article is firm's voice)
- Hedge words no longer exempt firm claims: "we typically sell in 18 days" correctly flags

Markdown structure fixes (from unmerged fix-perf-claims-markdown):
- Split on newlines + sentence boundaries
- Skip # headings and | table rows entirely

Performance noun list expanded: added base forms (sell, completion, transaction, property, exchange, letting) so "Our completion time is 10 weeks" and "We sell homes in 18 days" correctly flag.

Tests: 14 (9 false-positive, 5 true-positive), 47 total passing.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN