### PR TITLE
Replace regex firm-claims gate with semantic Haiku check at publish-time

### DIFF
--- a/services/approvalQueue.js
+++ b/services/approvalQueue.js
@@ -1,5 +1,7 @@
 import ApprovalQueue from '../models/ApprovalQueue.js';
 import { validateContentDraft } from './contentPlanner/validators.js';
+import { reviewDraftForFabrication } from './contentPlanner/fabricationReview.js';
+import { getFirmContext, renderFirmContextBlock } from './contentPlanner/firmContext.js';
 
 export async function createApproval({ vendorId, agentName, itemType, title, draftPayload, metadata, source }) {
   const item = new ApprovalQueue({
@@ -66,8 +68,37 @@ const executionHandlers = {
     }
 
     const { default: Vendor } = await import('../models/Vendor.js');
-    const vendor = await Vendor.findById(item.vendorId).select('_id').lean();
+    const vendor = await Vendor.findById(item.vendorId).lean();
     if (!vendor) throw new Error(`Vendor not found: ${item.vendorId}`);
+
+    // Semantic firm-performance-claim check (Haiku) — replaces the deterministic
+    // regex which false-positived on generic process descriptions and markdown.
+    // Fail-closed: API error or timeout blocks publish.
+    const allText = [payload.body, payload.linkedInText || '', payload.facebookText || ''].join('\n\n');
+    let firmContextBlock;
+    try {
+      const firmContext = await getFirmContext(item.vendorId);
+      firmContextBlock = renderFirmContextBlock(firmContext);
+    } catch (err) {
+      throw new Error(`Cannot load firm context for semantic check: ${err.message}`);
+    }
+
+    const semanticReview = await reviewDraftForFabrication({
+      draftText: allText,
+      firmContext: firmContextBlock,
+      vertical: vendor.vendorType,
+    });
+
+    if (semanticReview.verdict === 'fail') {
+      const claims = [
+        ...(semanticReview.fabricatedAttributions || []).map(a => `Fabricated attribution (${a.body}): "${a.claim}"`),
+        ...(semanticReview.firmClaimsNotInContext || []).map(c => `Unverified firm claim: "${c.claim}"`),
+      ];
+      const errorNote = semanticReview.error
+        ? `Semantic review error (fail-closed): ${semanticReview.error}`
+        : `Semantic review failed (quality ${semanticReview.qualityScore}/10): ${claims.join('; ')}`;
+      throw new Error(`Publish blocked — ${errorNote}`);
+    }
 
     const { default: VendorPost } = await import('../models/VendorPost.js');
     const post = new VendorPost({

--- a/services/contentPlanner/validators.js
+++ b/services/contentPlanner/validators.js
@@ -1,4 +1,4 @@
-import { detectPossibleFabrication, detectFirmPerformanceClaims } from './writerGuards.js';
+import { detectPossibleFabrication } from './writerGuards.js';
 
 /**
  * Pre-publish validator for Writer Agent content drafts.
@@ -159,11 +159,10 @@ export function validateContentDraft(payload) {
     errors.push(`Fabricated statistic attributed to ${f.body}: "${f.excerpt.trim()}"`);
   }
 
-  // Hard-block unverified firm performance claims (Rule 22).
-  const firmClaims = detectFirmPerformanceClaims(allText);
-  for (const f of firmClaims) {
-    errors.push(`Unverified firm performance claim: "${f.excerpt.trim()}"`);
-  }
+  // Firm performance claims are now checked semantically via Haiku at publish-time
+  // (in approvalQueue.js content_draft handler), not by the deterministic regex here.
+  // The regex detectFirmPerformanceClaims was removed from the publish path because
+  // it false-positived on generic process descriptions, markdown tables, and years.
 
   return {
     passed: errors.length === 0,

--- a/services/contentPlanner/writerGuards.js
+++ b/services/contentPlanner/writerGuards.js
@@ -120,6 +120,9 @@ const FIRM_SUBJECT = /\b(?:we|our|us|the firm|the team|the company)\b/i;
 // Generic-industry subjects — the claim is about the market/process, not the firm
 const GENERIC_SUBJECT = /\b(?:sales|conveyancing|transactions?|properties|the (?:average|typical|standard)|most|many|an? average)\b.*\b(?:typically|usually|generally|often|on average|normally|commonly|tend to|can take|range from)\b/i;
 
+// BYPASSED at publish-time — replaced by semantic Haiku check in approvalQueue.js.
+// Kept for reference/tests. The regex approach false-positived on generic process
+// descriptions, markdown tables, years, and industry vocabulary it couldn't generalise.
 export function detectFirmPerformanceClaims(draftText, firmName) {
   if (!draftText || typeof draftText !== 'string') return [];
 


### PR DESCRIPTION
The deterministic detectFirmPerformanceClaims regex false-positived on generic process descriptions, markdown tables, years, and industry vocabulary it couldn't generalise across verticals.

Proven replacement: the existing Haiku semantic check (reviewDraftForFabrication) correctly passes all 5 regex-false- positives while flagging genuine fabricated firm claims and passing claims that match the firm's verified firmData.

Changes:
1. validators.js: removed detectFirmPerformanceClaims call from validateContentDraft. detectPossibleFabrication (org-attribution regex) and placeholder check remain — both work correctly.
2. approvalQueue.js content_draft handler: added semantic Haiku check. Loads vendor context (getFirmContext + renderFirmContextBlock) and calls reviewDraftForFabrication with firmContext + vertical. Fail-closed: API error or timeout blocks publish. Claims listed in error message for admin visibility.
3. writerGuards.js: detectFirmPerformanceClaims marked as BYPASSED with comment explaining why. Function kept for reference/tests.

Fail-closed confirmed: all 3 error paths in fabricationReview.js (empty draft, API error, parse error) return verdict:'fail'.

Generation-time checkpoint unchanged — already uses the same Haiku check at writerAgent.js checkpoint 1b.

Tests: 53 passing, 7/7 proof checks pass.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN