### PR TITLE
fix(vendor): accept frontend service labels in services validation

### DIFF
--- a/models/Vendor.js
+++ b/models/Vendor.js
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt';
 import crypto from 'crypto'; // ADDED: ES modules import
 
 const validServices = ['CCTV', 'Photocopiers', 'IT', 'Telecoms', 'Security', 'Software',
+  'IT Services', 'Security Systems', 'Business Software',
   'Solicitors', 'Accountants', 'Mortgage Advisors', 'Estate Agents'];
 
 const vendorSchema = new mongoose.Schema({


### PR DESCRIPTION
The PUT /api/vendors/profile handler 500s for office-equipment vendors because the frontend submits friendly labels ("IT Services", "Security Systems", "Business Software") but validServices only contains short forms ("IT", "Security", "Software"). Add the friendly labels so both forms pass Mongoose validation.

Interim fix — frontend should be updated to submit canonical service values (IT/Security/Software) rather than display labels, to avoid duplicate service strings in stored data. Logged as follow-up.

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN