### PR TITLE
fix: replace retired claude-sonnet-4-20250514 with configurable SONNE…

### DIFF
--- a/lib/config/models.js
+++ b/lib/config/models.js
@@ -1,0 +1,1 @@
+export const SONNET_MODEL = process.env.ANTHROPIC_SONNET_MODEL || 'claude-sonnet-4-6';

--- a/routes/vendorPostRoutes.js
+++ b/routes/vendorPostRoutes.js
@@ -13,6 +13,7 @@ import { reviewDraftForFabrication } from '../services/contentPlanner/fabricatio
 import { detectPossibleFabrication, buildCtaForVendor } from '../services/contentPlanner/writerGuards.js';
 import { FIRM_DATA_KEYS } from '../services/writerAgent/firmDataKeys.js';
 import { countAllPlaceholders } from '../services/writerAgent/parsePlaceholders.js';
+import { SONNET_MODEL } from '../lib/config/models.js';
 
 const router = express.Router();
 
@@ -342,7 +343,7 @@ router.post('/:vendorId/posts/generate', vendorAuth, async (req, res) => {
     const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: SONNET_MODEL,
       max_tokens: 4000,
       temperature: 0.7,
       system: `${SYSTEM_PROMPT_WRITER_V1_1}\n\nCURRENT_YEAR: ${new Date().getFullYear()}\n\n${ORG_NAME_BAN}\n\n${firmContextBlock}`,

--- a/services/aeoReportGenerator.js
+++ b/services/aeoReportGenerator.js
@@ -22,6 +22,7 @@ import {
   isDualScoringEnabled,
 } from './scoring.js';
 import { mapScoreBreakdown } from './publicAeoReportBuilder.js';
+import { SONNET_MODEL } from '../lib/config/models.js';
 
 // ─── Category labels (human-readable) ────────────────────────────────────────
 
@@ -590,7 +591,7 @@ async function generateWithClaude(userPrompt) {
     for (let attempt = 0; attempt < 4; attempt++) {
       try {
         resp = await anthropic.messages.create({
-          model: 'claude-sonnet-4-20250514',
+          model: SONNET_MODEL,
           max_tokens: 4096,
           tools: searchTools,
           messages,

--- a/services/reporter/boardSummaryPrompt.js
+++ b/services/reporter/boardSummaryPrompt.js
@@ -1,3 +1,5 @@
+import { SONNET_MODEL } from '../../lib/config/models.js';
+
 export async function generateBoardSummary(anthropicClient, data) {
   const prompt = `You are writing the Board Summary section of an AI Visibility Intelligence Report for a UK SME. Write ONE paragraph (3-4 sentences) following these rules:
 
@@ -33,7 +35,7 @@ Use UK English. No marketing language. No bullet points. One paragraph.`;
 
   try {
     const response = await anthropicClient.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: SONNET_MODEL,
       max_tokens: 400,
       messages: [{ role: 'user', content: prompt }],
     });

--- a/services/reporter/claimAccuracyAudit.js
+++ b/services/reporter/claimAccuracyAudit.js
@@ -1,3 +1,5 @@
+import { SONNET_MODEL } from '../../lib/config/models.js';
+
 export async function auditClaims(vendor, anthropicClient, openaiClient) {
   const queries = [
     `What does ${vendor.company} specialise in?`,
@@ -82,7 +84,7 @@ function extractSpecialisations(text, vertical) {
 
 async function queryAnthropic(client, prompt) {
   try {
-    const resp = await client.messages.create({ model: 'claude-sonnet-4-20250514', max_tokens: 200, messages: [{ role: 'user', content: prompt }] });
+    const resp = await client.messages.create({ model: SONNET_MODEL, max_tokens: 200, messages: [{ role: 'user', content: prompt }] });
     return resp.content[0]?.text || '';
   } catch (e) { console.error('Claim audit Anthropic error:', e.message); return ''; }
 }

--- a/services/writerAgent.js
+++ b/services/writerAgent.js
@@ -11,12 +11,14 @@ import { createApproval } from './approvalQueue.js';
 import { buildCtaForVendor, detectPossibleFabrication } from './contentPlanner/writerGuards.js';
 import { FIRM_DATA_KEYS } from './writerAgent/firmDataKeys.js';
 
+import { SONNET_MODEL } from '../lib/config/models.js';
+
 const SONNET_INPUT_COST_PER_M = 3.00;
 const SONNET_OUTPUT_COST_PER_M = 15.00;
 const MONTHLY_COST_CAP_USD = 75;
 // 3 articles/week × ~4.33 weeks = max 14/month. Matches Pro tier promise in tendorai-what-you-get.pdf.
 const MONTHLY_PER_VENDOR_CAP = 14;
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = SONNET_MODEL;
 
 const PRO_TIERS = new Set(['pro', 'managed', 'verified', 'enterprise']);
 

--- a/tests/unit/writerAgent.test.js
+++ b/tests/unit/writerAgent.test.js
@@ -105,6 +105,8 @@ const {
   MONTHLY_COST_CAP_USD,
 } = await import('../../services/writerAgent.js');
 
+const { SONNET_MODEL } = await import('../../lib/config/models.js');
+
 const { default: AgentRun } = await import('../../models/AgentRun.js');
 
 // ─── Helpers ───────────────────────────────────────────────────
@@ -250,7 +252,7 @@ describe('Writer Agent', () => {
           costEstimateUSD: expect.any(Number),
           inputTokens: 4000,
           outputTokens: 3500,
-          model: 'claude-sonnet-4-20250514',
+          model: SONNET_MODEL,
         }),
       }));
     });
@@ -271,7 +273,7 @@ describe('Writer Agent', () => {
             costEstimateUSD: expect.any(Number),
             inputTokens: 4000,
             outputTokens: 3500,
-            model: 'claude-sonnet-4-20250514',
+            model: SONNET_MODEL,
           }),
           relatedApprovalIds: expect.any(Array),
         }),


### PR DESCRIPTION
…T_MODEL

Anthropic retired claude-sonnet-4-20250514 — all API calls using it return 404. This was hardcoded in 6 places, silently breaking the Writer Agent cron and the public report generator.

- Add lib/config/models.js as single source of truth: SONNET_MODEL = env.ANTHROPIC_SONNET_MODEL || 'claude-sonnet-4-6'
- Replace hardcoded string in all 5 service/route files
- Update writerAgent tests to assert against the constant

https://claude.ai/code/session_019t6hPvJS8XnSwstf8J9VBN